### PR TITLE
Add folder parameter to build-image command

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -57,14 +57,18 @@ commands:
         description: A docker image tag (default = latest)
         type: string
         default: "latest"
+      dockerfile:
+        description: Name of dockerfile to use. Defaults to Dockerfile.
+        type: string
+        default: Dockerfile
       path:
-        description: path to the directory containing your Dockerfile and build context
+        description: Path to the directory containing your Dockerfile and build context. Defaults to . (working directory).
         type: string
         default: .
     steps:
       - run:
           name: Build docker image
-          command: "docker build -t << parameters.account-url >>/<< parameters.repo >>:<< parameters.tag >> << parameters.path >>"
+          command: "docker build -f << parameters.dockerfile >> -t << parameters.account-url >>/<< parameters.repo >>:<< parameters.tag >> << parameters.path >>"
 
   push-image:
     description: "Push a container image to the Amazon ECR registry"

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -64,7 +64,7 @@ commands:
     steps:
       - run:
           name: Build docker image
-          command: "docker build -t <<parameters.account-url>>/<<parameters.repo>>:<<parameters.tag>> <<parameters.folder>>"
+          command: "docker build -t <<parameters.account-url>>/<<parameters.repo>>:<<parameters.tag>> <<parameters.path>>"
 
   push-image:
     description: "Push a container image to the Amazon ECR registry"

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -57,8 +57,8 @@ commands:
         description: A docker image tag (default = latest)
         type: string
         default: "latest"
-      folder:
-        description: Where the Dockerfile is located (default = current directory)
+      path:
+        description: path to the directory containing your Dockerfile and build context
         type: string
         default: .
     steps:

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -40,7 +40,7 @@ commands:
     steps:
       - run:
           name: Log into Amazon ECR
-          command: "$(aws ecr get-login --no-include-email --region <<parameters.region>> )"
+          command: "$(aws ecr get-login --no-include-email --region << parameters.region >> )"
 
   build-image:
     description: "Build a docker image"
@@ -64,7 +64,7 @@ commands:
     steps:
       - run:
           name: Build docker image
-          command: "docker build -t <<parameters.account-url>>/<<parameters.repo>>:<<parameters.tag>> <<parameters.path>>"
+          command: "docker build -t << parameters.account-url >>/<< parameters.repo >>:<< parameters.tag >> << parameters.path >>"
 
   push-image:
     description: "Push a container image to the Amazon ECR registry"
@@ -84,7 +84,7 @@ commands:
     steps:
       - run:
           name: Push image to Amazon ECR
-          command: "docker push <<parameters.account-url>>/<<parameters.repo>>:<<parameters.tag>>"
+          command: "docker push << parameters.account-url >>/<< parameters.repo >>:<< parameters.tag >>"
 
 jobs:
   build_and_push_image:

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -57,10 +57,14 @@ commands:
         description: A docker image tag (default = latest)
         type: string
         default: "latest"
+      folder:
+        description: Where the Dockerfile is located (default = current directory)
+        type: string
+        default: .
     steps:
       - run:
           name: Build docker image
-          command: "docker build -t <<parameters.account-url>>/<<parameters.repo>>:<<parameters.tag>> ."
+          command: "docker build -t <<parameters.account-url>>/<<parameters.repo>>:<<parameters.tag>> <<parameters.folder>>"
 
   push-image:
     description: "Push a container image to the Amazon ECR registry"


### PR DESCRIPTION
Hello there @iynere and @eddiewebb,

What do you guys think about adding a parameter **folder** to the **build-image** command?

My use case:
I have a repository with a lot of docker base images separated by folder, and I want to be able to switch folders and build these images.

Thanks!