### PR TITLE
Update build_and_push_image job and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ workflows:
       # build and push image to ECR
       - aws-ecr/build_and_push_image:
           context: myContext
-		  region: us-east-1
+          region: us-east-1
           account-url: 999999999999.dkr-ecr.us-west-2.amazonaws.com
           repo: myrepo
           tag: latest
+          dockerfile: Dockerfile
+          path: .
 ```
-

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -21,6 +21,8 @@ examples:
                 account-url: myAwsAccountId.dkr.ecr.myAwsRegion.amazonaws.com
                 repo: myRepo # your Amazon ECR repository
                 tag: latest
+                dockerfile: Dockerfile
+                path: .
 
 orbs:
   aws-cli: circleci/aws-cli@0.0.1
@@ -129,6 +131,14 @@ jobs:
         type: string
         description: Docker tag (default = latest)
         default: "latest"
+      dockerfile:
+        description: Name of dockerfile to use. Defaults to Dockerfile.
+        type: string
+        default: Dockerfile
+      path:
+        description: Path to the directory containing your Dockerfile and build context. Defaults to . (working directory).
+        type: string
+        default: .
     steps:
       - aws-cli/install
       - aws-cli/configure:
@@ -144,6 +154,8 @@ jobs:
           account-url: << parameters.account-url >>
           repo: << parameters.repo >>
           tag: << parameters.tag >>
+          dockerfile: << parameters.dockerfile >>
+          path: << parameters.path >>
       - push-image:
           account-url: << parameters.account-url >>
           repo: << parameters.repo >>


### PR DESCRIPTION
Hey @iynere and @eddiewebb... me again 😅 

I've updated the job **build_and_push_image**, so now it's possible to use the parameters:
- dockerfile
- path

Example:

```
...
workflows:
  build_and_push_image:
    jobs:
      - aws-ecr/build_and_push_image:
          context: myContext
          region: us-east-1
          account-url: 999999999999.dkr-ecr.us-west-2.amazonaws.com
          repo: myrepo
          tag: latest
          dockerfile: Dockerfile
          path: .
```

What do you guys think about this change?

Thanks!