### PR TITLE
Add extra-build-args parameter to build command

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -67,10 +67,21 @@ commands:
         description: Path to the directory containing your Dockerfile and build context. Defaults to . (working directory).
         type: string
         default: .
+      extra-build-args:
+        description: >
+          Extra flags to pass to docker build. For examples, see
+          https://docs.docker.com/engine/reference/commandline/build
+        type: string
+        default: ""
     steps:
       - run:
           name: Build docker image
-          command: "docker build -f << parameters.dockerfile >> -t << parameters.account-url >>/<< parameters.repo >>:<< parameters.tag >> << parameters.path >>"
+          command: >
+            docker build
+            <<# parameters.extra-build-args >><< parameters.extra-build-args >><</ parameters.extra-build-args >>
+            -f << parameters.dockerfile >>
+            -t << parameters.account-url >>/<< parameters.repo >>:<< parameters.tag >>
+            << parameters.path >>
 
   push-image:
     description: "Push a container image to the Amazon ECR registry"
@@ -139,6 +150,12 @@ jobs:
         description: Path to the directory containing your Dockerfile and build context. Defaults to . (working directory).
         type: string
         default: .
+      extra-build-args:
+        description: >
+          Extra flags to pass to docker build. For examples, see
+          https://docs.docker.com/engine/reference/commandline/build
+        type: string
+        default: ""
     steps:
       - aws-cli/install
       - aws-cli/configure:
@@ -156,6 +173,7 @@ jobs:
           tag: << parameters.tag >>
           dockerfile: << parameters.dockerfile >>
           path: << parameters.path >>
+          extra-build-args: << parameters.extra-build-args >>
       - push-image:
           account-url: << parameters.account-url >>
           repo: << parameters.repo >>


### PR DESCRIPTION
Hello there, @iynere and @eddiewebb,

Solves this issue: [issues#5](https://github.com/CircleCI-Public/aws-ecr-orb/issues/5), and maybe this one too [issues#4](https://github.com/CircleCI-Public/aws-ecr-orb/issues/4)

This pull request adds a new parameter: **extra-build-args**, to:
- **build** command
- **build_and_push_image** job

@FelixDuvalletKodiak as a workaround while this pull request isn't approved/merged, you can add your extra args like this:

```
- aws-ecr/build_and_push_image:
    dockerfile: Dockerfile --build-arg KEY=VALUE
```

Thank you!