### PR TITLE
Add lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Following is the full list of parameters required by this orb's various commands
 | `region` | `env_var_name` |  `AWS_REGION` | name of env var storing your AWS region |
 | `repo` | `string` |  N/A | name of your ECR repository |
 | `tag` | `string` |  `latest` | ECR image tag |
+| `after_checkout` | `steps` |  `[]` | Optional steps to run after checking out the code. |
+| `before_build` | `steps` |  `[]` | Optional steps to run before building the docker image. |
+| `after_build` | `steps` |  `[]` | Optional steps to run after building the docker image. |
 
 ## Usage
 See below for both simple and complete examples of this orb's `build_and_push_image` job. For details, see the [listing in the Orb Registry](https://circleci.com/orbs/registry/orb/circleci/aws-ecr).
@@ -83,6 +86,24 @@ workflows:
 
           # path to Dockerfile, defaults to . (working directory)
           path: pathToMyDockerfile
+
+          # Optional steps to run after checking out the code, defaults to []
+          after_checkout:
+            - run:
+                name: Do this after checkout.
+                command: echo "Did this after checkout"
+
+          # Optional steps to run before building the docker image, defaults to []
+          before_build:
+            - run:
+                name: Do this before the build.
+                command: echo "Did this before the build"
+
+          # Optional steps to run after building the docker image, default to []
+          after_build:
+            - run:
+                name: Do this after the build.
+                command: echo "Did this after the build"
 ```
 
 ## Contributing

--- a/src/jobs/build_and_push_image.yml
+++ b/src/jobs/build_and_push_image.yml
@@ -79,6 +79,21 @@ parameters:
     type: string
     default: ""
 
+  after_checkout:
+    description: Optional steps to run after checking out the code.
+    type: steps
+    default: []
+
+  before_build:
+    description: Optional steps to run before building the docker image.
+    type: steps
+    default: []
+
+  after_build:
+    description: Optional steps to run after building the docker image.
+    type: steps
+    default: []
+
 steps:
   - aws-cli/install
 
@@ -90,8 +105,18 @@ steps:
 
   - checkout
 
+  - when:
+      name: Run after_checkout lifecycle hook steps.
+      condition: << parameters.after_checkout >>
+      steps: << parameters.after_checkout >>
+
   - ecr-login:
       region: << parameters.region >>
+
+  - when:
+      name: Run before_build lifecycle hook steps.
+      condition: << parameters.before_build >>
+      steps: << parameters.before_build >>
 
   - build-image:
       account-url: << parameters.account-url >>
@@ -100,6 +125,11 @@ steps:
       dockerfile: << parameters.dockerfile >>
       path: << parameters.path >>
       extra-build-args: << parameters.extra-build-args >>
+
+  - when:
+      name: Run after_build lifecycle hook steps.
+      condition: << parameters.after_build >>
+      steps: << parameters.after_build >>
 
   - when:
       condition: <<parameters.create-repo>>


### PR DESCRIPTION
Add lifecycle hooks, inspired by this repo: [orb-docker-publish](https://circleci.com/orbs/registry/orb/circleci/docker-publish#usage-life_cycle_hooks)

My use case for the parameter: **after_checkout** is to attach a workspace (**attach_workspace** command) before building the docker image.

Does it make sense?

Thanks!

@iynere