### PR TITLE
Fix buggy behaviour of `create-repo` when repo exists

### DIFF
--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -132,7 +132,9 @@ steps:
   - when:
       condition: <<parameters.create-repo>>
       steps:
-        - run: aws --region $<<parameters.region>> ecr create-repository --repository-name <<parameters.repo>> --profile <<parameters.profile-name>>
+        - run: |
+            aws ecr describe-repositories --profile <<parameters.profile-name>> --region $<<parameters.region>> --repository-names <<parameters.repo>> > /dev/null 2>&1 || \
+            aws ecr create-repository --profile <<parameters.profile-name>> --region $<<parameters.region>> --repository-name <<parameters.repo>>
 
   - push-image:
       account-url: << parameters.account-url >>


### PR DESCRIPTION
This PR updates the `create-repo` handler to check if the repo exists before creating it.

Resolves #22.

Credit to @peermuellerxw in this comment for the code change: https://github.com/CircleCI-Public/aws-ecr-orb/issues/22#issuecomment-482042615