### PR TITLE
Fix orb documentation for repo parameter.

### DIFF
--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -49,7 +49,7 @@ parameters:
 
   repo:
     type: string
-    description: A URI to an Amazon ECR repository
+    description: Name of the Amazon ECR repository.
 
   create-repo:
     type: boolean

--- a/src/jobs/build_and_push_image.yml
+++ b/src/jobs/build_and_push_image.yml
@@ -50,7 +50,7 @@ parameters:
 
   repo:
     type: string
-    description: A URI to an Amazon ECR repository
+    description: Name of the Amazon ECR repository.
 
   create-repo:
     type: boolean


### PR DESCRIPTION
Fixes #30 

Documentation fix. However, as mentioned in #30, maybe `repo` should be a URI and not a name since it's the only required parameter?