### PR TITLE
Support secondary account of Amazon ECR

### DIFF
--- a/src/commands/ecr-login-for-secondary-account.yml
+++ b/src/commands/ecr-login-for-secondary-account.yml
@@ -1,0 +1,23 @@
+description: "Authenticate into the Amazon ECR service"
+
+parameters:
+  region:
+    description: >
+      Name of env var storing your AWS region information,
+      defaults to AWS_REGION
+    type: env_var_name
+    default: AWS_REGION
+
+  account-id:
+    type: string
+    description: Account ID of an Amazon ECR repository
+
+steps:
+  - run:
+      name: Log into Amazon ECR
+      command: |
+        # aws ecr get-login returns a login command w/ a temp token
+        LOGIN_COMMAND=$(aws ecr get-login --no-include-email --region $<< parameters.region >> --registry-ids $<< parameters.account-id >>)
+
+        # save it to an env var & use that env var to login
+        $LOGIN_COMMAND

--- a/src/commands/ecr-login-for-secondary-account.yml
+++ b/src/commands/ecr-login-for-secondary-account.yml
@@ -2,22 +2,25 @@ description: "Authenticate into the Amazon ECR service"
 
 parameters:
   region:
-    description: >
-      Name of env var storing your AWS region information,
-      defaults to AWS_REGION
     type: env_var_name
     default: AWS_REGION
+    description: >
+      Name of environment variable storing AWS region information,
+      defaults to AWS_REGION
 
   account-id:
-    type: string
-    description: Account ID of an Amazon ECR repository
+    type: env_var_name
+    default: AWS_ECR_REPO_ACCOUNT_ID
+    description: >
+      Name of environment variable storing the Amazon ECR repository's
+      account ID
 
 steps:
   - run:
       name: Log into Amazon ECR
       command: |
         # aws ecr get-login returns a login command w/ a temp token
-        LOGIN_COMMAND=$(aws ecr get-login --no-include-email --region $<< parameters.region >> --registry-ids $<< parameters.account-id >>)
+        LOGIN_COMMAND=$(aws ecr get-login --no-include-email --region $<<parameters.region>> --registry-ids $<<parameters.account-id>>)
 
         # save it to an env var & use that env var to login
         $LOGIN_COMMAND


### PR DESCRIPTION
Hi. I'm excited about Orbs!

I tried aws-ecr@4.0.1 and found a missing feature.
The purpose of this PR is to add a secondary account login.

ref: [How can I grant access to a secondary account to pull or push images in my ECR repository?](https://aws.amazon.com/premiumsupport/knowledge-center/secondary-account-access-ecr/)