### PR TITLE
Increase timeout

### DIFF
--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -27,6 +27,11 @@ parameters:
     type: string
     default: .
 
+  no-output-timeout:
+    description: The amount of time to allow the docker command to run before timing out.
+    type: string
+    default: 10m
+
   extra-build-args:
     description: >
       Extra flags to pass to docker build. For examples, see
@@ -43,6 +48,6 @@ steps:
           -f <<parameters.dockerfile>> \
           -t $<<parameters.account-url>>/<<parameters.repo>>:<<parameters.tag>> \
           <<parameters.path>>
-      no_output_timeout: 1h
+      no_output_timeout: <<parameters.no-output-timeout>>
 
 

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -43,3 +43,6 @@ steps:
           -f <<parameters.dockerfile>> \
           -t $<<parameters.account-url>>/<<parameters.repo>>:<<parameters.tag>> \
           <<parameters.path>>
+      no_output_timeout: 1h
+
+


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

We're presently getting timeouts on our long running angular builds. ~40m.  I tried forking the ORB, but because of this other bug, I cannot at this time publish my own ORBs: https://discuss.circleci.com/t/unable-to-create-namespace-for-my-organization/31426/4 .  The ability to control the timeout should be part of the base orb IMO anyway.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Add the ability to set circle's no_output_timeout setting which can be useful in allowing long running docker constructions.
