### PR TITLE
[CIRCLE-19768] Remove orb publishing context from integration test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,6 @@ workflows:
 
       - aws-ecr/build-and-push-image:
           name: integration-tests-dev
-          context: orb-publishing
           attach-workspace: true
           workspace-root: workspace
           profile-name: testing
@@ -94,7 +93,6 @@ workflows:
 
       - aws-ecr/build-and-push-image:
           name: integration-tests-master
-          context: orb-publishing
           attach-workspace: true
           workspace-root: workspace
           profile-name: testing


### PR DESCRIPTION
Use a new set of IAM credentials for the ecr orb, and provide them via project env variables instead

### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Use an IAM account customized for the ECR orb instead of the current one in the context.
See CIRCLE-19768.

### Description

The project now has the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION, AWS_ECR_ACCOUNT_URL and AWS_DEFAULT_REGION project environment variables defined and can use the values from them.