### PR TITLE
Add set-repository-policy to pull with secondary-account-ids

### DIFF
--- a/src/commands/set-policy.yml
+++ b/src/commands/set-policy.yml
@@ -1,0 +1,68 @@
+description: "Set policy to pull a repository with secondary ids"
+parameters:
+
+  secondary-account-ids:
+    description: A comma-separated string containing secondary-account-ids
+    type: env_var_name
+    default: AWS_SECONDARY_ACCOUNT_IDS
+
+  profile-name:
+    default: default
+    description: AWS profile name to be configured.
+    type: string
+
+  region:
+    description: >
+      Name of env var storing your AWS region information,
+      defaults to AWS_REGION
+    type: env_var_name
+    default: AWS_REGION
+
+  repo:
+    type: string
+    description: Name of an Amazon ECR repository
+
+steps:
+  - run:
+      name: Build to create an IAM policy to pull a repository
+      command: |
+        iam_permissions=""
+
+        IFS="," read -r -a SECONDARY_IDS \<<< "<< parameters.secondary-account-ids >>"
+
+        for index in "${!SECONDARY_IDS[@]}"
+        do
+            if [ $index -gt 0 ]
+            then
+                iam_permissions+=", "
+            fi
+            iam_permissions+="\"${SECONDARY_IDS[index]}\""
+        done
+
+        cat \<< EOM > policy.json
+        {
+          "Version": "2008-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": [${iam_permissions}]
+              },
+              "Action": [
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:BatchGetImage"
+              ]
+            }
+          ]
+        }
+        EOM
+
+        aws ecr set-repository-policy \
+            --profile <<parameters.profile-name>> \
+            --region $<<parameters.region>> \
+            --repository-name <<parameters.repo>> \
+            --policy-text \
+          file://policy.json
+
+        rm -f policy.json


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues
Resolves #28
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
- add a new command to set a repository policy to be able to pull with secondary id's 
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
