### PR TITLE
Add `no-output-timeout` parameter to `build-and-push-image`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Following is the full list of parameters required by this orb's various commands
 | `region` | `env_var_name` |  `AWS_REGION` | name of env var storing your AWS region |
 | `repo` | `string` |  N/A | name of your ECR repository |
 | `tag` | `string` |  `latest` | Comma-separated string of ECR image tags |
+| `no-output-timeout` | `string` |  `latest` | The amount of time to allow the docker build command to run before timing out (default is `10m`) |
 
 ## Usage
 See below for both simple and complete examples of this orb's `build_and_push_image` job. For details, see the [listing in the Orb Registry](https://circleci.com/orbs/registry/orb/circleci/aws-ecr).
@@ -83,6 +84,9 @@ workflows:
 
           # path to Dockerfile, defaults to . (working directory)
           path: pathToMyDockerfile
+
+          # The amount of time to allow the docker build command to run before timing out (default is `10m`)
+          no-output-timeout: 15m
 ```
 
 ## Contributing

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -105,6 +105,12 @@ parameters:
     type: string
     default: ""
 
+  no-output-timeout:
+    description: >
+      The amount of time to allow the docker build command to run before timing out (default is `10m`)
+    type: string
+    default: "10m"
+
 steps:
   - when:
       condition: <<parameters.checkout>>
@@ -140,6 +146,7 @@ steps:
       dockerfile: <<parameters.dockerfile>>
       path: <<parameters.path>>
       extra-build-args: <<parameters.extra-build-args>>
+      no-output-timeout: <<parameters.no-output-timeout>>
 
   - when:
       condition: <<parameters.create-repo>>


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
Allow the use of the `no-output-timeout` flag on the main command `build-and-push-image`. Without this the only way of increasing the build timeout, is calling the `build-and-push-image` subcommands separately, passing the `no-output-timeout` parameter to the `build-image` command.

### Description
A new parameter called `no-output-timeout` is added to the `build-and-push-image` and then passed to the `build-image` command.
