### PR TITLE
adding multiple templates for github issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,10 @@
+---
+name: "Bug report"
+about: Create a report to help improve the project
+labels: bug
+
+---
+
 ### Orb version
 
 <!---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: "Feature request"
+about: Suggest an idea that will improve the project
+labels: enhancement
+
+---
+
+## What would you like to be added
+
+<!---
+  please describe the idea you have and the problem you are trying to solve
+-->
+
+## Why is this needed
+
+<!---
+  please explain why is this feature needed and how it improves the project
+-->


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

Existing single GitHub template for issues is planned to be deprecated in the future and Github itself recommends updating the repo to new issue template workflow.

<img width="1002" alt="Screenshot 2019-10-10 10 19 26" src="https://user-images.githubusercontent.com/3473617/66555737-6e7adc00-eb4f-11e9-80d2-49ef97d0ffb8.png">

### Description

* remove existing single issue template
* add issue template for bug report with proper label
* add issue template for feature request with proper label
