### PR TITLE
Docker layer caching

### DIFF
--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -22,7 +22,8 @@ parameters:
     type: boolean
     default: false
     description: >
-      If using setup-remote-docker, should docker_layer_caching be enabled (https://circleci.com/docs/2.0/docker-layer-caching/)
+      If using setup-remote-docker, should docker_layer_caching be enabled
+      (https://circleci.com/docs/2.0/docker-layer-caching/)
 
   profile-name:
     description: AWS profile name to be configured.

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -18,6 +18,12 @@ parameters:
       Setup and use CircleCI's remote Docker environment for Docker and
       docker-compose commands? Not required if using the default executor
 
+  docker-layer-caching:
+    type: boolean
+    default: false
+    description: >
+      If using setup-remote-docker, should docker_layer_caching be enabled (https://circleci.com/docs/2.0/docker-layer-caching/)
+
   profile-name:
     description: AWS profile name to be configured.
     type: string
@@ -134,7 +140,8 @@ steps:
   - when:
       condition: <<parameters.setup-remote-docker>>
       steps:
-        - setup_remote_docker
+        - setup_remote_docker:
+          docker_layer_caching: <<parameters.docker-layer-caching>>
 
   - ecr-login:
       region: <<parameters.region>>

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -89,6 +89,13 @@ parameters:
     description: >
       Setup and use CircleCI's remote Docker environment for Docker and
       docker-compose commands? Not required if using the default executor
+    
+  docker-layer-caching:
+    type: boolean
+    default: false
+    description: >
+      If using setup-remote-docker, should docker_layer_caching be enabled
+      (https://circleci.com/docs/2.0/docker-layer-caching/)
 
   dockerfile:
     description: Name of dockerfile to use. Defaults to Dockerfile.
@@ -111,6 +118,7 @@ steps:
   - build-and-push-image:
       profile-name: <<parameters.profile-name>>
       setup-remote-docker: <<parameters.setup-remote-docker>>
+      docker-layer-caching: <<parameters.docker-layer-caching>>
       aws-access-key-id: <<parameters.aws-access-key-id>>
       aws-secret-access-key: <<parameters.aws-secret-access-key>>
       region: <<parameters.region>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

https://github.com/CircleCI-Public/aws-ecr-orb/issues/67
Allows enabling docker_layer_caching when using this orb with setup-remote-docker

### Description

Add `docker-layer-caching` parameter to set `docker_layer_caching` on `setup_remote_docker`
