### PR TITLE
Include profile name for ECR login

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,46 @@ workflows:
           name: integration-tests-dev
           attach-workspace: true
           workspace-root: workspace
+          profile-name: default
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}
+          create-repo: true
+          tag: integration-dev,myECRRepoTag
+          dockerfile: workspace/Dockerfile
+          path: workspace
+          extra-build-args: --compress
+          filters: *integration-dev_filters
+          post-steps: *integration-post-steps
+          requires: [pre-integration-dev]
+
+      # triggered by master branch commits
+      - pre-integration-checkout-workspace-job:
+          name: pre-integration-master
+          filters: *integration-master_filters
+
+      - aws-ecr/build-and-push-image:
+          name: integration-tests-master
+          attach-workspace: true
+          workspace-root: workspace
+          profile-name: default
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}
+          create-repo: true
+          tag: integration-master,myECRRepoTag
+          dockerfile: workspace/Dockerfile
+          path: workspace
+          extra-build-args: --compress
+          filters: *integration-master_filters
+          post-steps: *integration-post-steps
+          requires: [pre-integration-master]
+
+      # triggered by non-master branch commits
+      - pre-integration-checkout-workspace-job:
+          name: pre-integration-dev
+          filters: *integration-dev_filters
+
+      - aws-ecr/build-and-push-image:
+          name: integration-tests-dev
+          attach-workspace: true
+          workspace-root: workspace
           profile-name: testing
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}
           create-repo: true

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -137,6 +137,7 @@ steps:
         - setup_remote_docker
 
   - ecr-login:
+      profile-name: <<parameters.profile-name>>
       region: <<parameters.region>>
 
   - build-image:

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -8,12 +8,17 @@ parameters:
     type: env_var_name
     default: AWS_REGION
 
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: "default"
+
 steps:
   - run:
       name: Log into Amazon ECR
       command: |
         # aws ecr get-login returns a login command w/ a temp token
-        LOGIN_COMMAND=$(aws ecr get-login --no-include-email --region $<<parameters.region>>)
+        LOGIN_COMMAND=$(aws ecr get-login --no-include-email --region $<<parameters.region>> --profile $<<parameters.profile-name>>)
 
         # save it to an env var & use that env var to login
         $LOGIN_COMMAND


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

I have multiple AWS accounts and wanting to deploy to both of them with two sets of credentials.

`aws ecr get-login` will only honor the first credentials.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Adding the ability to pass a `profile-name` to `ecr-login`.