### PR TITLE
Use path parameter for Dockerfile argument

### DIFF
--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -50,7 +50,7 @@ steps:
         done
         docker build \
           <<#parameters.extra-build-args>><<parameters.extra-build-args>><</parameters.extra-build-args>> \
-          -f <<parameters.dockerfile>> \
+          -f <<parameters.path>>/<<parameters.dockerfile>> \
           $docker_tag_args \
           <<parameters.path>>
       no_output_timeout: <<parameters.no-output-timeout>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

PR opened per issue #64 

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

The `build-image` command now uses the `path` parameter when pointing to a Dockerfile. The same implementation is used in the Docker orb (https://github.com/CircleCI-Public/docker-orb/blob/master/src/commands/build.yml#L107-L119)
