### PR TITLE
create stale bot rules

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -15,11 +15,11 @@ daysUntilClose: 7
 exemptLabels:
   - pinned
   - security
-  
+
 # only issues with these labesl will be considered ([] is disabling this rule, look at all issues except excempt)
-onlyLabels: []  
-  
-  
+onlyLabels: []
+
+
 # Label to use when marking an issue as stale
 staleLabel: wontfix
 
@@ -28,6 +28,6 @@ markComment: >
   This issue has been automatically marked as stale because it has not had
   recent activity. It will be closed if no further activity occurs. Thank you
   for your contributions.
-  
+
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,33 @@
+# Stale Issue & PR Rules
+#
+# See https://github.com/probot/stale#usage for values
+#
+
+
+
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  
+# only issues with these labesl will be considered ([] is disabling this rule, look at all issues except excempt)
+onlyLabels: []  
+  
+  
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+  
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,9 +2,6 @@
 #
 # See https://github.com/probot/stale#usage for values
 #
-
-
-
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 60
 
@@ -15,10 +12,12 @@ daysUntilClose: 7
 exemptLabels:
   - pinned
   - security
+  - confirmed
+  - bug
+  - enhancement
 
 # only issues with these labesl will be considered ([] is disabling this rule, look at all issues except excempt)
 onlyLabels: []
-
 
 # Label to use when marking an issue as stale
 staleLabel: stale

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -21,7 +21,7 @@ onlyLabels: []
 
 
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >


### PR DESCRIPTION
adds initial stale.yml file with 60 day policy.


### Motivation, issues

Some issues are months (years!) old and actually invald given platform changes since report.  This will add GitHub's stale bot to mark and eventually close stale issues and PRs unless a user objects and shows continued engagement,
