### PR TITLE
updated for returning image sha

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Following is the full list of parameters required by this orb's various commands
 | `region` | `env_var_name` |  `AWS_REGION` | name of env var storing your AWS region |
 | `repo` | `string` |  N/A | name of your ECR repository |
 | `tag` | `string` |  `latest` | Comma-separated string of ECR image tags |
+| `return-sha-var` | `string` |  `SHA256` | set this to the variable you want returned with the image SHA |
 | `no-output-timeout` | `string` |  `latest` | The amount of time to allow the docker build command to run before timing out (default is `10m`) |
 
 ## Usage
@@ -82,6 +83,9 @@ workflows:
 
           # ECR image tags (comma-separated string), defaults to "latest"
           tag: latest,myECRRepoTag
+
+          # The return variable desired for the container SHA (default is `SHA256`)
+          return-sha-var: MYIMAGE
 
           # name of Dockerfile to use, defaults to "Dockerfile"
           dockerfile: myDockerfile

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -73,6 +73,11 @@ parameters:
     default: "latest"
     description: A comma-separated string containing docker image tags to build and push (default = latest)
 
+  return-sha-var:
+    description: Variable you want set with the container sha (default = SHA256)
+    type: string
+    default: SHA256
+
   checkout:
     type: boolean
     default: true
@@ -164,3 +169,4 @@ steps:
       account-url: <<parameters.account-url>>
       repo: <<parameters.repo>>
       tag: <<parameters.tag>>
+      return-sha-var: <<parameters.return-sha-var>>

--- a/src/commands/push-image.yml
+++ b/src/commands/push-image.yml
@@ -18,11 +18,18 @@ parameters:
     type: string
     default: "latest"
 
+  return-sha-var:
+    description: Variable you want set with the container sha (default = SHA256)
+    type: string
+    default: SHA256
+
 steps:
   - run:
       name: Push image to Amazon ECR
       command: |
         IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
         for tag in "${DOCKER_TAGS[@]}"; do
-          docker push $<<parameters.account-url>>/<<parameters.repo>>:${tag}
+          PUSH=$(docker push $<<parameters.account-url>>/<<parameters.repo>>:${tag})
+          echo $PUSH
         done
+        export <<parameters.return-sha-var>>=$(echo $PUSH | grep sha256 | cut -d " " -f3)

--- a/src/commands/push-image.yml
+++ b/src/commands/push-image.yml
@@ -29,8 +29,9 @@ steps:
       command: |
         IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
         for tag in "${DOCKER_TAGS[@]}"; do
-          PUSH=$(docker push $<<parameters.account-url>>/<<parameters.repo>>:${tag})
-          echo $PUSH
+          PUSH=$(docker push $<<parameters.account-url>>/<<parameters.repo>>:${tag} | base64 --wrap=0)
+          echo $PUSH | base64 --decode
         done
-        SHA=$(echo $PUSH | grep sha256 | cut -d " " -f3)
-        echo `export <<parameters.return-sha-var>>="$SHA"` >> $BASH_ENV
+        SHA=$(echo $PUSH | base64 --decode | grep sha256 | cut -d " " -f3)
+        echo "SHA: $SHA"
+        echo "export <<parameters.return-sha-var>>=${SHA}" >> "$BASH_ENV"

--- a/src/commands/push-image.yml
+++ b/src/commands/push-image.yml
@@ -33,5 +33,4 @@ steps:
           echo $PUSH | base64 --decode
         done
         SHA=$(echo $PUSH | base64 --decode | grep sha256 | cut -d " " -f3)
-        echo "SHA: $SHA"
         echo "export <<parameters.return-sha-var>>=${SHA}" >> "$BASH_ENV"

--- a/src/commands/push-image.yml
+++ b/src/commands/push-image.yml
@@ -29,8 +29,8 @@ steps:
       command: |
         IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
         for tag in "${DOCKER_TAGS[@]}"; do
-          PUSH=$(docker push $<<parameters.account-url>>/<<parameters.repo>>:${tag} | base64 --wrap=0)
-          echo $PUSH | base64 --decode
+        ECR_IMG_PUSH=$(docker push $<<parameters.account-url>>/<<parameters.repo>>:${tag} | base64 --wrap=0)
+          echo $ECR_IMG_PUSH | base64 --decode
         done
-        SHA=$(echo $PUSH | base64 --decode | grep sha256 | cut -d " " -f3)
-        echo "export <<parameters.return-sha-var>>=${SHA}" >> "$BASH_ENV"
+        ECR_IMG_SHA256=$(echo $ECR_IMG_PUSH | base64 --decode | grep sha256 | cut -d " " -f3)
+        echo "export <<parameters.return-sha-var>>=${ECR_IMG_SHA256}" >> "$BASH_ENV"

--- a/src/commands/push-image.yml
+++ b/src/commands/push-image.yml
@@ -32,4 +32,4 @@ steps:
           PUSH=$(docker push $<<parameters.account-url>>/<<parameters.repo>>:${tag})
           echo $PUSH
         done
-        export <<parameters.return-sha-var>>=$(echo $PUSH | grep sha256 | cut -d " " -f3)
+        echo `export <<parameters.return-sha-var>>=$(echo $PUSH | grep sha256 | cut -d " " -f3)` >> $BASH_ENV

--- a/src/commands/push-image.yml
+++ b/src/commands/push-image.yml
@@ -32,4 +32,5 @@ steps:
           PUSH=$(docker push $<<parameters.account-url>>/<<parameters.repo>>:${tag})
           echo $PUSH
         done
-        echo `export <<parameters.return-sha-var>>=$(echo $PUSH | grep sha256 | cut -d " " -f3)` >> $BASH_ENV
+        SHA=$(echo $PUSH | grep sha256 | cut -d " " -f3)
+        echo `export <<parameters.return-sha-var>>="$SHA"` >> $BASH_ENV


### PR DESCRIPTION
this allows for using the image sha down the pipe seemlessly

### Motivation, issues

Using the container sha is a common pattern, if multiple consecutive builds occurred I'd like to not deploy with a tag that may or may not be the most current.

### Description

adds sha256 output from ecr pushes
