### PR TITLE
ECR get-login with profile [semver:minor]

### DIFF
--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -142,6 +142,7 @@ steps:
         - setup_remote_docker
 
   - ecr-login:
+      profile-name: <<parameters.profile-name>>
       region: <<parameters.region>>
 
   - build-image:

--- a/src/commands/ecr-login-for-secondary-account.yml
+++ b/src/commands/ecr-login-for-secondary-account.yml
@@ -27,7 +27,7 @@ steps:
       name: Log into Amazon ECR
       command: |
         # aws ecr get-login returns a login command w/ a temp token
-        LOGIN_COMMAND=$(aws ecr get-login --no-include-email --region $<<parameters.region>> --registry-ids $<<parameters.account-id>> --profile $<<parameters.profile-name>>)
+        LOGIN_COMMAND=$(aws ecr get-login --no-include-email --region $<<parameters.region>> --registry-ids $<<parameters.account-id>> --profile <<parameters.profile-name>>)
 
         # save it to an env var & use that env var to login
         $LOGIN_COMMAND

--- a/src/commands/ecr-login-for-secondary-account.yml
+++ b/src/commands/ecr-login-for-secondary-account.yml
@@ -15,12 +15,19 @@ parameters:
       Name of environment variable storing the Amazon ECR repository's
       account ID
 
+  profile-name:
+    type: string
+    default: "default"
+    description: >
+      AWS profile name to be configured.
+      defaults to "default"
+
 steps:
   - run:
       name: Log into Amazon ECR
       command: |
         # aws ecr get-login returns a login command w/ a temp token
-        LOGIN_COMMAND=$(aws ecr get-login --no-include-email --region $<<parameters.region>> --registry-ids $<<parameters.account-id>>)
+        LOGIN_COMMAND=$(aws ecr get-login --no-include-email --region $<<parameters.region>> --registry-ids $<<parameters.account-id>> --profile $<<parameters.profile-name>>)
 
         # save it to an env var & use that env var to login
         $LOGIN_COMMAND

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -20,7 +20,7 @@ steps:
       name: Log into Amazon ECR
       command: |
         # aws ecr get-login returns a login command w/ a temp token
-        LOGIN_COMMAND=$(aws ecr get-login --no-include-email --region $<<parameters.region>> --profile $<<parameters.profile-name>>)
+        LOGIN_COMMAND=$(aws ecr get-login --no-include-email --region $<<parameters.region>> --profile <<parameters.profile-name>>)
 
         # save it to an env var & use that env var to login
         $LOGIN_COMMAND

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -8,12 +8,19 @@ parameters:
       Name of env var storing your AWS region information,
       defaults to AWS_REGION
 
+  profile-name:
+    type: string
+    default: "default"
+    description: >
+      AWS profile name to be configured.
+      defaults to "default"
+
 steps:
   - run:
       name: Log into Amazon ECR
       command: |
         # aws ecr get-login returns a login command w/ a temp token
-        LOGIN_COMMAND=$(aws ecr get-login --no-include-email --region $<<parameters.region>>)
+        LOGIN_COMMAND=$(aws ecr get-login --no-include-email --region $<<parameters.region>> --profile $<<parameters.profile-name>>)
 
         # save it to an env var & use that env var to login
         $LOGIN_COMMAND


### PR DESCRIPTION
As discussed in the issue below, we added the ability to specify a profile when generating an ecr login URL. 

### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

https://github.com/CircleCI-Public/aws-ecr-orb/issues/9

### Description

`aws ecr get-login` can accept the `--profile` flag to specify key and secrets credentials.

