### PR TITLE
Use AWS_DEFAULT_REGION as default region environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ workflows:
           # name of env var storing your AWS Secret Access Key, defaults to AWS_SECRET_ACCESS_KEY
           aws-secret-access-key: SECRET_ACCESS_KEY_ENV_VAR_NAME
 
-          # name of env var storing your AWS region, defaults to AWS_REGION
+          # name of env var storing your AWS region, defaults to AWS_DEFAULT_REGION
           region: AWS_REGION_ENV_VAR_NAME
 
           # name of env var storing your ECR account URL, defaults to AWS_ECR_ACCOUNT_URL

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -41,10 +41,10 @@ parameters:
 
   region:
     type: env_var_name
-    default: AWS_REGION
+    default: AWS_DEFAULT_REGION
     description: >
       Name of env var storing your AWS region information,
-      defaults to AWS_REGION
+      defaults to AWS_DEFAULT_REGION
 
   account-url:
     type: env_var_name

--- a/src/commands/ecr-login-for-secondary-account.yml
+++ b/src/commands/ecr-login-for-secondary-account.yml
@@ -3,10 +3,10 @@ description: "Authenticate into the Amazon ECR service"
 parameters:
   region:
     type: env_var_name
-    default: AWS_REGION
+    default: AWS_DEFAULT_REGION
     description: >
       Name of environment variable storing AWS region information,
-      defaults to AWS_REGION
+      defaults to AWS_DEFAULT_REGION
 
   account-id:
     type: env_var_name

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -3,10 +3,10 @@ description: "Authenticate into the Amazon ECR service"
 parameters:
   region:
     type: env_var_name
-    default: AWS_REGION
+    default: AWS_DEFAULT_REGION
     description: >
       Name of env var storing your AWS region information,
-      defaults to AWS_REGION
+      defaults to AWS_DEFAULT_REGION
 
 steps:
   - run:

--- a/src/examples/simple-build-and-push.yml
+++ b/src/examples/simple-build-and-push.yml
@@ -24,7 +24,7 @@ usage:
             # name of env var storing your AWS Secret Access Key, defaults to AWS_SECRET_ACCESS_KEY
             aws-secret-access-key: SECRET_ACCESS_KEY_ENV_VAR_NAME
 
-            # name of env var storing your AWS region, defaults to AWS_REGION
+            # name of env var storing your AWS region, defaults to AWS_DEFAULT_REGION
             region: AWS_REGION_ENV_VAR_NAME
 
             # name of env var storing your ECR account URL, defaults to AWS_ECR_ACCOUNT_URL

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -36,10 +36,10 @@ parameters:
 
   region:
     type: env_var_name
-    default: AWS_REGION
+    default: AWS_DEFAULT_REGION
     description: >
       Name of env var storing your AWS region information,
-      defaults to AWS_REGION
+      defaults to AWS_DEFAULT_REGION
 
   account-url:
     type: env_var_name


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [] All new jobs, commands, executors, parameters have descriptions
- [] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

See #91 

### Description
Sets the default environment variable for `region` to `AWS_DEFAULT_REGION` to bring it in line with the AWS CLI and the AWS CLI CircleCI orb.
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
