### PR TITLE
Fix env var AWS_ACCESS_KEY_ID typo [semver:patch]

### DIFF
--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -24,7 +24,7 @@ parameters:
     description: >
       AWS access key id for IAM role. Set this to the name of
       the environment variable you will set to hold this
-      value, i.e. AWS_ACCESS_KEY.
+      value, i.e. AWS_ACCESS_KEY_ID.
 
   aws-secret-access-key:
     type: env_var_name


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

There is a typo in the doc regarding env var AWS_ACCESS_KEY_ID

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
Fix the typo by changing the description.
