### PR TITLE
[semver:minor] Make 'build-image' command more friendly

### DIFF
--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -39,6 +39,18 @@ parameters:
       Extra flags to pass to docker build. For examples, see
       https://docs.docker.com/engine/reference/commandline/build
 
+  checkout:
+    type: boolean
+    default: false
+    description: >
+      Boolean for whether or not to checkout as a first step. Default is false.
+
+  ecr-login:
+    type: boolean
+    default: false
+    description: >
+      Boolean for whether or not to log in to ECR before building. Default is false.
+
   skip-when-tags-exist:
     type: boolean
     default: false
@@ -50,14 +62,14 @@ parameters:
     description: >
       Name of env var storing your AWS region information,
       defaults to AWS_REGION. Only required when skip-when-tags-exist
-      is set to true.
+      or ecr-login are set to true.
 
   profile-name:
     type: string
     default: "default"
     description: >
       AWS profile name to be configured. Only required when skip-when-tags-exist
-      is set to true.
+      or ecr-login are set to true.
 
   aws-access-key-id:
     type: env_var_name
@@ -77,7 +89,15 @@ parameters:
 
 steps:
   - when:
-      condition: <<parameters.skip-when-tags-exist>>
+      condition: <<parameters.checkout>>
+      steps:
+        - checkout
+
+  - when:
+      condition:
+        or:
+          - <<parameters.ecr-login>>
+          - <<parameters.skip-when-tags-exist>>
       steps:
         - ecr-login:
             profile-name: <<parameters.profile-name>>


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

- I want to use the `build-image` command directly to make sure the images build on pull requests
- Some of my images are based off other private ECR images, so still need to auth

### Description

- Add a `checkout` param to the `build-image` command so we can match the API of `build-and-push-image` (but with default `false` so we don't checkout twice when using the build and push)
- Move all the AWS CLI stuff under the `ecr-login` command so that we can use it in both build and build&push.
