### PR TITLE
Add missing `no-output-timeout` paramter in `jobs/build-and-push-image.yml` [semver:minor]

### DIFF
--- a/src/examples/simple-build-and-push.yml
+++ b/src/examples/simple-build-and-push.yml
@@ -44,3 +44,6 @@ usage:
 
             # path to Dockerfile, defaults to . (working directory)
             path: pathToMyDockerfile
+
+            # The amount of time to allow the docker build command to run before timing out, defaults to "10m"
+            no-output-timeout: 20m

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -107,6 +107,12 @@ parameters:
       Extra flags to pass to docker build. For examples, see
       https://docs.docker.com/engine/reference/commandline/build
 
+  no-output-timeout:
+    type: string
+    default: "10m"
+    description: >
+      The amount of time to allow the docker build command to run before timing out. Defaults to '10m'
+
 steps:
   - build-and-push-image:
       profile-name: <<parameters.profile-name>>
@@ -124,3 +130,4 @@ steps:
       dockerfile: <<parameters.dockerfile>>
       path: <<parameters.path>>
       extra-build-args: <<parameters.extra-build-args>>
+      no-output-timeout: <<parameters.no-output-timeout>>


### PR DESCRIPTION

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
#61 added `no-output-timeout` parameter, but `Unexpected argument(s): no-output-timeout` is produced by CircleCI when it's being used.
Cause of this issue is `no-output-timeout` paramter is not passed in `jobs/build-and-push-image.yml`, so it cannot be recognized by CirclecI andproduces error `Unexpected argument(s): no-output-timeout`

### Description
Add `no-output-timeout` parameter in `jobs/build-and-push-image.yml` file to fix this issue
