### PR TITLE
[semver:minor] skip building image when tags already exist in ecr repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,16 +86,16 @@ workflows:
           requires: [integration-tests-default-profile]
 
       - aws-ecr/build-and-push-image:
-          name: integration-tests-skip-build-when-tags-exist-in-ecr
+          name: integration-tests-skip-when-tags-exist
           attach-workspace: true
           workspace-root: workspace
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}
           create-repo: true
-          tag: skip-build-when-tags-exist-in-ecr
+          tag: skip-when-tags-exist
           dockerfile: sample/Dockerfile
           path: workspace
           extra-build-args: --compress
-          skip-build-when-tags-exist-in-ecr: true
+          skip-when-tags-exist: true
           post-steps: *integration-post-steps
           executor:
             name: aws-ecr/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ workflows:
           executor:
             name: aws-ecr/default
             use-docker-layer-caching: true
-          requires: [integration-tests-named-profile]
+          requires: [integration-tests-default-profile]
 
       - orb-tools/dev-promote-prod-from-commit-subject:
           orb-name: circleci/aws-ecr

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ workflows:
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}
           create-repo: true
           tag: skip-build-when-tags-exist-in-ecr
-          dockerfile: Dockerfile
+          dockerfile: sample/Dockerfile
           path: workspace
           extra-build-args: --compress
           skip-build-when-tags-exist-in-ecr: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ workflows:
           workspace-root: workspace
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}
           create-repo: true
-          tag: integration,myECRRepoTag
+          tag: skip-build-when-tags-exist-in-ecr
           dockerfile: Dockerfile
           path: workspace
           extra-build-args: --compress

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,23 @@ workflows:
             use-docker-layer-caching: true
           requires: [integration-tests-default-profile]
 
+      - aws-ecr/build-and-push-image:
+          name: integration-tests-skip-build-when-tags-exist-in-ecr
+          attach-workspace: true
+          workspace-root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}
+          create-repo: true
+          tag: integration,myECRRepoTag
+          dockerfile: Dockerfile
+          path: workspace
+          extra-build-args: --compress
+          skip-build-when-tags-exist-in-ecr: true
+          post-steps: *integration-post-steps
+          executor:
+            name: aws-ecr/default
+            use-docker-layer-caching: true
+          requires: [integration-tests-named-profile]
+
       - orb-tools/dev-promote-prod-from-commit-subject:
           orb-name: circleci/aws-ecr
           context: orb-publishing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ workflows:
           executor:
             name: aws-ecr/default
             use-docker-layer-caching: true
-          requires: [integration-tests-default-profile]
+          requires: [integration-tests-named-profile]
 
       - orb-tools/dev-promote-prod-from-commit-subject:
           orb-name: circleci/aws-ecr

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ workflows:
 
           # Set to true if you don't want to build the image if it already exists in the ECR repo, for example when
           # you are tagging with the git commit hash. Specially useful for faster code reverts.
-          skip-build-when-tags-exist-in-ecr: false
+          skip-when-tags-exist: false
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ workflows:
 
           # The amount of time to allow the docker build command to run before timing out (default is `10m`)
           no-output-timeout: 15m
+
+          # Set to true if you don't want to build the image if it already exists in the ECR repo, for example when
+          # you are tagging with the git commit hash. Specially useful for faster code reverts.
+          skip-build-when-tags-exist-in-ecr: false
 ```
 
 ## Contributing

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -116,7 +116,7 @@ parameters:
     description: >
       The amount of time to allow the docker build command to run before timing out (default is `10m`)
 
-  skip-build-when-tags-exist-in-ecr:
+  skip-when-tags-exist:
     type: boolean
     default: false
     description: Whether to skip image building if all specified tags already exist in ECR
@@ -160,7 +160,7 @@ steps:
       path: <<parameters.path>>
       extra-build-args: <<parameters.extra-build-args>>
       no-output-timeout: <<parameters.no-output-timeout>>
-      skip-build-when-tags-exist-in-ecr: <<parameters.skip-build-when-tags-exist-in-ecr>>
+      skip-when-tags-exist: <<parameters.skip-when-tags-exist>>
       profile-name: <<parameters.profile-name>>
       region: <<parameters.region>>
       aws-access-key-id: <<parameters.aws-access-key-id>>

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -138,31 +138,19 @@ steps:
       steps:
         - setup_remote_docker
 
+  - ecr-login:
+      profile-name: <<parameters.profile-name>>
+      region: <<parameters.region>>
+      account-url: <<parameters.account-url>>
+      aws-access-key-id: <<parameters.aws-access-key-id>>
+      aws-secret-access-key: <<parameters.aws-secret-access-key>>
+
   - when:
       condition: <<parameters.create-repo>>
       steps:
-        - aws-cli/install
-
-        - aws-cli/setup:
-            profile-name: <<parameters.profile-name>>
-            aws-access-key-id: <<parameters.aws-access-key-id>>
-            aws-secret-access-key: <<parameters.aws-secret-access-key>>
-            aws-region: <<parameters.region>>
-
         - run: |
             aws ecr describe-repositories --profile <<parameters.profile-name>> --region $<<parameters.region>> --repository-names <<parameters.repo>> > /dev/null 2>&1 || \
             aws ecr create-repository --profile <<parameters.profile-name>> --region $<<parameters.region>> --repository-name <<parameters.repo>> --image-scanning-configuration scanOnPush=<<parameters.repo-scan-on-push>>
-
-  - when:
-      condition:
-        not: <<parameters.skip-build-when-tags-exist-in-ecr>>
-      steps:
-        - ecr-login:
-            profile-name: <<parameters.profile-name>>
-            region: <<parameters.region>>
-            account-url: <<parameters.account-url>>
-            aws-access-key-id: <<parameters.aws-access-key-id>>
-            aws-secret-access-key: <<parameters.aws-secret-access-key>>
 
   - build-image:
       account-url: <<parameters.account-url>>

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -149,6 +149,13 @@ steps:
             aws-access-key-id: <<parameters.aws-access-key-id>>
             aws-secret-access-key: <<parameters.aws-secret-access-key>>
 
+  - when:
+      condition: <<parameters.create-repo>>
+      steps:
+        - run: |
+            aws ecr describe-repositories --profile <<parameters.profile-name>> --region $<<parameters.region>> --repository-names <<parameters.repo>> > /dev/null 2>&1 || \
+            aws ecr create-repository --profile <<parameters.profile-name>> --region $<<parameters.region>> --repository-name <<parameters.repo>> --image-scanning-configuration scanOnPush=<<parameters.repo-scan-on-push>>
+
   - build-image:
       account-url: <<parameters.account-url>>
       repo: <<parameters.repo>>
@@ -160,13 +167,6 @@ steps:
       skip-build-when-tags-exist-in-ecr: <<parameters.skip-build-when-tags-exist-in-ecr>>
       profile-name: <<parameters.profile-name>>
       region: <<parameters.region>>
-
-  - when:
-      condition: <<parameters.create-repo>>
-      steps:
-        - run: |
-            aws ecr describe-repositories --profile <<parameters.profile-name>> --region $<<parameters.region>> --repository-names <<parameters.repo>> > /dev/null 2>&1 || \
-            aws ecr create-repository --profile <<parameters.profile-name>> --region $<<parameters.region>> --repository-name <<parameters.repo>> --image-scanning-configuration scanOnPush=<<parameters.repo-scan-on-push>>
 
   - push-image:
       account-url: <<parameters.account-url>>

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -116,19 +116,16 @@ parameters:
     description: >
       The amount of time to allow the docker build command to run before timing out (default is `10m`)
 
+  skip-build-when-tags-exist-in-ecr:
+    type: boolean
+    default: false
+    description: Whether to skip image building if all specified tags already exist in ECR
+
 steps:
   - when:
       condition: <<parameters.checkout>>
       steps:
         - checkout
-
-  - aws-cli/install
-
-  - aws-cli/configure:
-      profile-name: <<parameters.profile-name>>
-      aws-access-key-id: <<parameters.aws-access-key-id>>
-      aws-secret-access-key: <<parameters.aws-secret-access-key>>
-      aws-region: <<parameters.region>>
 
   - when:
       condition: <<parameters.attach-workspace>>
@@ -141,10 +138,16 @@ steps:
       steps:
         - setup_remote_docker
 
-  - ecr-login:
-      profile-name: <<parameters.profile-name>>
-      region: <<parameters.region>>
-      account-url: <<parameters.account-url>>
+  - when:
+      condition:
+        not: <<parameters.skip-build-when-tags-exist-in-ecr>>
+      steps:
+        - ecr-login:
+            profile-name: <<parameters.profile-name>>
+            region: <<parameters.region>>
+            account-url: <<parameters.account-url>>
+            aws-access-key-id: <<parameters.aws-access-key-id>>
+            aws-secret-access-key: <<parameters.aws-secret-access-key>>
 
   - build-image:
       account-url: <<parameters.account-url>>
@@ -154,6 +157,9 @@ steps:
       path: <<parameters.path>>
       extra-build-args: <<parameters.extra-build-args>>
       no-output-timeout: <<parameters.no-output-timeout>>
+      skip-build-when-tags-exist-in-ecr: <<parameters.skip-build-when-tags-exist-in-ecr>>
+      profile-name: <<parameters.profile-name>>
+      region: <<parameters.region>>
 
   - when:
       condition: <<parameters.create-repo>>

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -138,19 +138,31 @@ steps:
       steps:
         - setup_remote_docker
 
-  - ecr-login:
-      profile-name: <<parameters.profile-name>>
-      region: <<parameters.region>>
-      account-url: <<parameters.account-url>>
-      aws-access-key-id: <<parameters.aws-access-key-id>>
-      aws-secret-access-key: <<parameters.aws-secret-access-key>>
-
   - when:
       condition: <<parameters.create-repo>>
       steps:
+        - aws-cli/install
+
+        - aws-cli/setup:
+            profile-name: <<parameters.profile-name>>
+            aws-access-key-id: <<parameters.aws-access-key-id>>
+            aws-secret-access-key: <<parameters.aws-secret-access-key>>
+            aws-region: <<parameters.region>>
+
         - run: |
             aws ecr describe-repositories --profile <<parameters.profile-name>> --region $<<parameters.region>> --repository-names <<parameters.repo>> > /dev/null 2>&1 || \
             aws ecr create-repository --profile <<parameters.profile-name>> --region $<<parameters.region>> --repository-name <<parameters.repo>> --image-scanning-configuration scanOnPush=<<parameters.repo-scan-on-push>>
+
+  - when:
+      condition:
+        not: <<parameters.skip-build-when-tags-exist-in-ecr>>
+      steps:
+        - ecr-login:
+            profile-name: <<parameters.profile-name>>
+            region: <<parameters.region>>
+            account-url: <<parameters.account-url>>
+            aws-access-key-id: <<parameters.aws-access-key-id>>
+            aws-secret-access-key: <<parameters.aws-secret-access-key>>
 
   - build-image:
       account-url: <<parameters.account-url>>
@@ -163,6 +175,8 @@ steps:
       skip-build-when-tags-exist-in-ecr: <<parameters.skip-build-when-tags-exist-in-ecr>>
       profile-name: <<parameters.profile-name>>
       region: <<parameters.region>>
+      aws-access-key-id: <<parameters.aws-access-key-id>>
+      aws-secret-access-key: <<parameters.aws-secret-access-key>>
 
   - push-image:
       account-url: <<parameters.account-url>>

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -138,16 +138,12 @@ steps:
       steps:
         - setup_remote_docker
 
-  - when:
-      condition:
-        not: <<parameters.skip-build-when-tags-exist-in-ecr>>
-      steps:
-        - ecr-login:
-            profile-name: <<parameters.profile-name>>
-            region: <<parameters.region>>
-            account-url: <<parameters.account-url>>
-            aws-access-key-id: <<parameters.aws-access-key-id>>
-            aws-secret-access-key: <<parameters.aws-secret-access-key>>
+  - ecr-login:
+      profile-name: <<parameters.profile-name>>
+      region: <<parameters.region>>
+      account-url: <<parameters.account-url>>
+      aws-access-key-id: <<parameters.aws-access-key-id>>
+      aws-secret-access-key: <<parameters.aws-secret-access-key>>
 
   - when:
       condition: <<parameters.create-repo>>

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -59,10 +59,34 @@ parameters:
       AWS profile name to be configured. Only required when skip-build-when-tags-exist-in-ecr
       is set to true.
 
+  aws-access-key-id:
+    type: env_var_name
+    default: AWS_ACCESS_KEY_ID
+    description: >
+      AWS access key id for IAM role. Set this to the name of
+      the environment variable you will set to hold this
+      value, i.e. AWS_ACCESS_KEY.
+
+  aws-secret-access-key:
+    type: env_var_name
+    default: AWS_SECRET_ACCESS_KEY
+    description: >
+      AWS secret key for IAM role. Set this to the name of
+      the environment variable you will set to hold this
+      value, i.e. AWS_SECRET_ACCESS_KEY.
+
 steps:
   - when:
       condition: <<parameters.skip-build-when-tags-exist-in-ecr>>
       steps:
+        - aws-cli/install
+
+        - aws-cli/setup:
+            profile-name: <<parameters.profile-name>>
+            aws-access-key-id: <<parameters.aws-access-key-id>>
+            aws-secret-access-key: <<parameters.aws-secret-access-key>>
+            aws-region: <<parameters.region>>
+
         - ecr-login:
             profile-name: <<parameters.profile-name>>
             region: <<parameters.region>>

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -39,7 +39,7 @@ parameters:
       Extra flags to pass to docker build. For examples, see
       https://docs.docker.com/engine/reference/commandline/build
 
-  skip-build-when-tags-exist-in-ecr:
+  skip-when-tags-exist:
     type: boolean
     default: false
     description: Whether to skip image building if all specified tags already exist in ECR
@@ -49,14 +49,14 @@ parameters:
     default: AWS_REGION
     description: >
       Name of env var storing your AWS region information,
-      defaults to AWS_REGION. Only required when skip-build-when-tags-exist-in-ecr
+      defaults to AWS_REGION. Only required when skip-when-tags-exist
       is set to true.
 
   profile-name:
     type: string
     default: "default"
     description: >
-      AWS profile name to be configured. Only required when skip-build-when-tags-exist-in-ecr
+      AWS profile name to be configured. Only required when skip-when-tags-exist
       is set to true.
 
   aws-access-key-id:
@@ -77,7 +77,7 @@ parameters:
 
 steps:
   - when:
-      condition: <<parameters.skip-build-when-tags-exist-in-ecr>>
+      condition: <<parameters.skip-when-tags-exist>>
       steps:
         - ecr-login:
             profile-name: <<parameters.profile-name>>
@@ -95,12 +95,12 @@ steps:
         docker_tag_args=""
         IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
         for tag in "${DOCKER_TAGS[@]}"; do
-          if [ "<<parameters.skip-build-when-tags-exist-in-ecr>>" = "true" ]; then
+          if [ "<<parameters.skip-when-tags-exist>>" = "true" ]; then
             docker_tags_exist_in_ecr=$(aws ecr describe-images --registry-id $registry_id --repository-name <<parameters.repo>> --query "contains(imageDetails[].imageTags[], '$tag')")
           fi
           docker_tag_args="$docker_tag_args -t $<<parameters.account-url>>/<<parameters.repo>>:$tag"
         done
-        if [ "<<parameters.skip-build-when-tags-exist-in-ecr>>" = "false" ] || [ "<<parameters.skip-build-when-tags-exist-in-ecr>>" = "true" -a "$docker_tags_exist_in_ecr" = "false" ]; then
+        if [ "<<parameters.skip-when-tags-exist>>" = "false" ] || [ "<<parameters.skip-when-tags-exist>>" = "true" -a "$docker_tags_exist_in_ecr" = "false" ]; then
           docker build \
             <<#parameters.extra-build-args>><<parameters.extra-build-args>><</parameters.extra-build-args>> \
             -f <<parameters.path>>/<<parameters.dockerfile>> \

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -71,7 +71,7 @@ steps:
   - run:
       name: Build docker image
       command: |
-        registry_id=$(echo $<<parameters.account-url>> | sed "s;\.\w;;g")
+        registry_id=$(echo $<<parameters.account-url>> | sed "s;\..*;;g")
         docker_tags_exist_in_ecr="false"
 
         docker_tag_args=""

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -79,18 +79,12 @@ steps:
   - when:
       condition: <<parameters.skip-build-when-tags-exist-in-ecr>>
       steps:
-        - aws-cli/install
-
-        - aws-cli/setup:
-            profile-name: <<parameters.profile-name>>
-            aws-access-key-id: <<parameters.aws-access-key-id>>
-            aws-secret-access-key: <<parameters.aws-secret-access-key>>
-            aws-region: <<parameters.region>>
-
         - ecr-login:
             profile-name: <<parameters.profile-name>>
             region: <<parameters.region>>
             account-url: <<parameters.account-url>>
+            aws-access-key-id: <<parameters.aws-access-key-id>>
+            aws-secret-access-key: <<parameters.aws-secret-access-key>>
 
   - run:
       name: Build docker image

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -39,20 +39,56 @@ parameters:
       Extra flags to pass to docker build. For examples, see
       https://docs.docker.com/engine/reference/commandline/build
 
+  skip-build-when-tags-exist-in-ecr:
+    type: boolean
+    default: false
+    description: Whether to skip image building if all specified tags already exist in ECR
+
+  region:
+    type: env_var_name
+    default: AWS_REGION
+    description: >
+      Name of env var storing your AWS region information,
+      defaults to AWS_REGION. Only required when skip-build-when-tags-exist-in-ecr
+      is set to true.
+
+  profile-name:
+    type: string
+    default: "default"
+    description: >
+      AWS profile name to be configured. Only required when skip-build-when-tags-exist-in-ecr
+      is set to true.
+
 steps:
+  - when:
+      condition: <<parameters.skip-build-when-tags-exist-in-ecr>>
+      steps:
+        - ecr-login:
+            profile-name: <<parameters.profile-name>>
+            region: <<parameters.region>>
+            account-url: <<parameters.account-url>>
+
   - run:
       name: Build docker image
       command: |
+        registry_id=$(echo <<parameters.account-url>> | sed "s;\.\w;;g")
+        docker_tags_exist_in_ecr="false"
+
         docker_tag_args=""
         IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
         for tag in "${DOCKER_TAGS[@]}"; do
+          if [ "<<parameters.skip-build-when-tags-exist-in-ecr>>" = "true" ]; then
+            docker_tags_exist_in_ecr=$(aws ecr describe-images --registry-id $registry_id --repository-name <<parameters.repo>> --query "contains(imageDetails[].imageTags[], '$tag')")
+          fi
           docker_tag_args="$docker_tag_args -t $<<parameters.account-url>>/<<parameters.repo>>:$tag"
         done
-        docker build \
-          <<#parameters.extra-build-args>><<parameters.extra-build-args>><</parameters.extra-build-args>> \
-          -f <<parameters.path>>/<<parameters.dockerfile>> \
-          $docker_tag_args \
-          <<parameters.path>>
+        if [ "<<parameters.skip-build-when-tags-exist-in-ecr>>" = "false" ] || [ "<<parameters.skip-build-when-tags-exist-in-ecr>>" = "true" -a "$docker_tags_exist_in_ecr" = "false" ]; then
+          docker build \
+            <<#parameters.extra-build-args>><<parameters.extra-build-args>><</parameters.extra-build-args>> \
+            -f <<parameters.path>>/<<parameters.dockerfile>> \
+            $docker_tag_args \
+            <<parameters.path>>
+        fi
       no_output_timeout: <<parameters.no-output-timeout>>
 
 

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -71,7 +71,7 @@ steps:
   - run:
       name: Build docker image
       command: |
-        registry_id=$(echo <<parameters.account-url>> | sed "s;\.\w;;g")
+        registry_id=$(echo $<<parameters.account-url>> | sed "s;\.\w;;g")
         docker_tags_exist_in_ecr="false"
 
         docker_tag_args=""

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -42,7 +42,7 @@ parameters:
 steps:
   - aws-cli/install
 
-  - aws-cli/configure:
+  - aws-cli/setup:
       profile-name: <<parameters.profile-name>>
       aws-access-key-id: <<parameters.aws-access-key-id>>
       aws-secret-access-key: <<parameters.aws-secret-access-key>>

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -23,7 +23,31 @@ parameters:
       AWS profile name to be configured.
       defaults to "default"
 
+  aws-access-key-id:
+    type: env_var_name
+    default: AWS_ACCESS_KEY_ID
+    description: >
+      AWS access key id for IAM role. Set this to the name of
+      the environment variable you will set to hold this
+      value, i.e. AWS_ACCESS_KEY.
+
+  aws-secret-access-key:
+    type: env_var_name
+    default: AWS_SECRET_ACCESS_KEY
+    description: >
+      AWS secret key for IAM role. Set this to the name of
+      the environment variable you will set to hold this
+      value, i.e. AWS_SECRET_ACCESS_KEY.
+
 steps:
+  - aws-cli/install
+
+  - aws-cli/configure:
+      profile-name: <<parameters.profile-name>>
+      aws-access-key-id: <<parameters.aws-access-key-id>>
+      aws-secret-access-key: <<parameters.aws-secret-access-key>>
+      aws-region: <<parameters.region>>
+
   - run:
       name: Log into Amazon ECR
       command: |

--- a/src/examples/simple-build-and-push.yml
+++ b/src/examples/simple-build-and-push.yml
@@ -50,4 +50,4 @@ usage:
 
             # Set to true if you don't want to build the image if it already exists in the ECR repo, for example when
             # you are tagging with the git commit hash. Specially useful for faster code reverts.
-            skip-build-when-tags-exist-in-ecr: false
+            skip-when-tags-exist: false

--- a/src/examples/simple-build-and-push.yml
+++ b/src/examples/simple-build-and-push.yml
@@ -47,3 +47,7 @@ usage:
 
             # The amount of time to allow the docker build command to run before timing out, defaults to "10m"
             no-output-timeout: 20m
+
+            # Set to true if you don't want to build the image if it already exists in the ECR repo, for example when
+            # you are tagging with the git commit hash. Specially useful for faster code reverts.
+            skip-build-when-tags-exist-in-ecr: false

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -113,7 +113,7 @@ parameters:
     description: >
       The amount of time to allow the docker build command to run before timing out. Defaults to '10m'
 
-  skip-build-when-tags-exist-in-ecr:
+  skip-when-tags-exist:
     type: boolean
     default: false
     description: Whether to skip image building if all specified tags already exist in ECR
@@ -136,4 +136,4 @@ steps:
       path: <<parameters.path>>
       extra-build-args: <<parameters.extra-build-args>>
       no-output-timeout: <<parameters.no-output-timeout>>
-      skip-build-when-tags-exist-in-ecr: <<parameters.skip-build-when-tags-exist-in-ecr>>
+      skip-when-tags-exist: <<parameters.skip-when-tags-exist>>

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -113,6 +113,11 @@ parameters:
     description: >
       The amount of time to allow the docker build command to run before timing out. Defaults to '10m'
 
+  skip-build-when-tags-exist-in-ecr:
+    type: boolean
+    default: false
+    description: Whether to skip image building if all specified tags already exist in ECR
+
 steps:
   - build-and-push-image:
       profile-name: <<parameters.profile-name>>
@@ -131,3 +136,4 @@ steps:
       path: <<parameters.path>>
       extra-build-args: <<parameters.extra-build-args>>
       no-output-timeout: <<parameters.no-output-timeout>>
+      skip-build-when-tags-exist-in-ecr: <<parameters.skip-build-when-tags-exist-in-ecr>>


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

When using a tagging strategy based on the git commit hash it is unnecessary to spend time rebuilding an image that has been already pushed to the ECR repository. This is particularly relevant when wanting to revert to a previous deployment in production, saving precious time that would have been otherwise spent building the same image that already exists in ECR.

### Description

* I've tried my best to keep things backwards compatible, hopefully succeeded at it?
* To avoid repetition I've moved the aws-cli install and configuration into the ecr-login step, as that's when it's needed.
