### PR TITLE
[semver:minor] #103 - Pin AWS CLI orb to version 1.2.x.

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -7,4 +7,4 @@ display:
   source_url: https://github.com/CircleCI-Public/aws-ecr-orb
 
 orbs:
-  aws-cli: circleci/aws-cli@0.1.13
+  aws-cli: circleci/aws-cli@1.2

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -124,7 +124,7 @@ steps:
 
   - aws-cli/install
 
-  - aws-cli/configure:
+  - aws-cli/setup:
       profile-name: <<parameters.profile-name>>
       aws-access-key-id: <<parameters.aws-access-key-id>>
       aws-secret-access-key: <<parameters.aws-secret-access-key>>


### PR DESCRIPTION
Pins AWS CLI orb to version 1.2.x, from 0.1.13.