### PR TITLE
[semver:skip] Move sample Dockerfile, remove alpha script.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
 
       - persist_to_workspace:
           root: .
-          paths: Dockerfile
+          paths: [sample/Dockerfile]
 
 integration-post-steps: &integration-post-steps
   [run: "aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7} --force"]
@@ -62,7 +62,7 @@ workflows:
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}
           create-repo: true
           tag: integration,myECRRepoTag
-          dockerfile: Dockerfile
+          dockerfile: sample/Dockerfile
           path: workspace
           extra-build-args: --compress
           post-steps: *integration-post-steps
@@ -76,7 +76,7 @@ workflows:
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}
           create-repo: true
           tag: integration,myECRRepoTag
-          dockerfile: Dockerfile
+          dockerfile: sample/Dockerfile
           path: workspace
           extra-build-args: --compress
           post-steps: *integration-post-steps

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM readytalk/nodejs
-
-# Add our configuration files and scripts
-WORKDIR /app
-ADD . /app
-EXPOSE 80
-
-ENTRYPOINT ["/nodejs/bin/npm", "start"]

--- a/publish-alpha.sh
+++ b/publish-alpha.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-circleci config pack src > orb.yml
-circleci orb publish orb.yml circleci/aws-ecr@dev:alpha
-rm -rf orb.yml

--- a/sample/Dockerfile
+++ b/sample/Dockerfile
@@ -1,0 +1,7 @@
+FROM cimg/node:14.4
+
+WORKDIR /app
+ADD . /app
+EXPOSE 80
+
+ENTRYPOINT ["npm", "start"]


### PR DESCRIPTION
Removes the `publish-alpha.sh` script and moves the Dockerfile to the `sample/` directory, as per https://circleci.com/docs/2.0/orbs-best-practices/#sample-data