### PR TITLE
[semver:patch] fix the skip-when-tags-exist condition and fix docker push failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,6 @@ jobs:
           root: .
           paths: [sample/Dockerfile]
 
-integration-post-steps: &integration-post-steps
-  [run: "aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7} --force"]
-
 workflows:
   lint-pack_validate_deploy-dev:
     unless: << pipeline.parameters.run-integration-tests >>
@@ -51,7 +48,6 @@ workflows:
   integration-tests_deploy-prod:
     when: << pipeline.parameters.run-integration-tests >>
     jobs:
-
       - pre-integration-checkout-workspace-job:
           name: pre-integration
 
@@ -59,13 +55,14 @@ workflows:
           name: integration-tests-default-profile
           attach-workspace: true
           workspace-root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
           create-repo: true
           tag: integration,myECRRepoTag
           dockerfile: sample/Dockerfile
           path: workspace
           extra-build-args: --compress
-          post-steps: *integration-post-steps
+          post-steps:
+            - run: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile --force
           requires: [pre-integration]
 
       - aws-ecr/build-and-push-image:
@@ -73,34 +70,52 @@ workflows:
           attach-workspace: true
           workspace-root: workspace
           profile-name: testing
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
           create-repo: true
           tag: integration,myECRRepoTag
           dockerfile: sample/Dockerfile
           path: workspace
           extra-build-args: --compress
-          post-steps: *integration-post-steps
+          post-steps:
+            - run: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile --force
           executor:
             name: aws-ecr/default
             use-docker-layer-caching: true
-          requires: [integration-tests-default-profile]
+          requires: [pre-integration]
+
+      - aws-ecr/build-and-push-image:
+          name: integration-tests-skip-when-tags-exist-populate-image
+          attach-workspace: true
+          workspace-root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist
+          create-repo: true
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra-build-args: --compress
+          skip-when-tags-exist: true
+          executor:
+            name: aws-ecr/default
+            use-docker-layer-caching: true
+          requires: [pre-integration]
 
       - aws-ecr/build-and-push-image:
           name: integration-tests-skip-when-tags-exist
           attach-workspace: true
           workspace-root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist
           create-repo: true
-          tag: skip-when-tags-exist
+          tag: integration,myECRRepoTag
           dockerfile: sample/Dockerfile
           path: workspace
           extra-build-args: --compress
           skip-when-tags-exist: true
-          post-steps: *integration-post-steps
+          post-steps:
+            - run: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist --force
           executor:
             name: aws-ecr/default
             use-docker-layer-caching: true
-          requires: [integration-tests-named-profile]
+          requires: [integration-tests-skip-when-tags-exist-populate-image]
 
       - orb-tools/dev-promote-prod-from-commit-subject:
           orb-name: circleci/aws-ecr
@@ -114,4 +129,7 @@ workflows:
           filters:
             branches:
               only: master
-          requires: [integration-tests-named-profile]
+          requires:
+            - integration-tests-default-profile
+            - integration-tests-named-profile
+            - integration-tests-skip-when-tags-exist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,6 @@ workflows:
           attach-workspace: true
           workspace-root: workspace
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist
-          create-repo: true
           tag: integration,myECRRepoTag
           dockerfile: sample/Dockerfile
           path: workspace

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -90,17 +90,21 @@ steps:
       name: Build docker image
       command: |
         registry_id=$(echo $<<parameters.account-url>> | sed "s;\..*;;g")
-        docker_tags_exist_in_ecr="false"
+        number_of_tags_in_ecr=0
 
         docker_tag_args=""
         IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
         for tag in "${DOCKER_TAGS[@]}"; do
           if [ "<<parameters.skip-when-tags-exist>>" = "true" ]; then
-            docker_tags_exist_in_ecr=$(aws ecr describe-images --registry-id $registry_id --repository-name <<parameters.repo>> --query "contains(imageDetails[].imageTags[], '$tag')")
+            docker_tag_exists_in_ecr=$(aws ecr describe-images --registry-id $registry_id --repository-name <<parameters.repo>> --query "contains(imageDetails[].imageTags[], '$tag')")
+            if [ "$docker_tag_exists_in_ecr" = "true" ]; then
+              docker pull $<<parameters.account-url>>/<<parameters.repo>>:${tag}
+              let "number_of_tags_in_ecr+=1"
+            fi
           fi
           docker_tag_args="$docker_tag_args -t $<<parameters.account-url>>/<<parameters.repo>>:$tag"
         done
-        if [ "<<parameters.skip-when-tags-exist>>" = "false" ] || [ "<<parameters.skip-when-tags-exist>>" = "true" -a "$docker_tags_exist_in_ecr" = "false" ]; then
+        if [ "<<parameters.skip-when-tags-exist>>" = "false" ] || [ "<<parameters.skip-when-tags-exist>>" = "true" -a $number_of_tags_in_ecr -lt ${#DOCKER_TAGS[@]} ]; then
           docker build \
             <<#parameters.extra-build-args>><<parameters.extra-build-args>><</parameters.extra-build-args>> \
             -f <<parameters.path>>/<<parameters.dockerfile>> \


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

This is a PR to fix two issues with my previous PR (https://github.com/CircleCI-Public/aws-ecr-orb/pull/105):
1. The image building was being skipped when *any* tag existed in ECR, as opposed to *all* tags existing, as intended and documented.
2. The docker push command was failing when image building was skipped, as there were no images to push. The existing images are now pulled from ECR so that this push can succeed (it will be very quick as the layers already exist in the remote so nothing will be uploaded).

### Description

Added an actual test for the scenario of the image building being skipped when it already exists.
I'm also changing the circleci config to run the integration tests in parallel, for faster feedback
