### PR TITLE
[semver:patch] Remove duplicate 'aws-cli/setup' step

### DIFF
--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -40,8 +40,6 @@ parameters:
       value, i.e. AWS_SECRET_ACCESS_KEY.
 
 steps:
-  - aws-cli/install
-
   - aws-cli/setup:
       profile-name: <<parameters.profile-name>>
       aws-access-key-id: <<parameters.aws-access-key-id>>


### PR DESCRIPTION
Fixes #109

### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Currently the AWS CLI gets installed twice, this should fix that

### Description

In the latest version of the aws-cli orb, the `setup` command includes the install, so we don't need to run that from this orb.

https://github.com/CircleCI-Public/aws-cli-orb/blob/v1.2.1/src/commands/setup.yml#L59
