### PR TITLE
feat: allows to set custom docker version if using docker executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ workflows:
           # name of your ECR repository
           repo: myECRRepository
 
+          # set this to use CircleCI's remote Docker environment for Docker and docker-compose commands,
+          # defaults to "false"
+          setup-remote-docker: true
+
+          # when setup-remote-docker is true, customize docker engine version (default is `17.09.0-ce`)
+          remote-docker-version: 19.03.13
+
           # set this to true to create the repository if it does not already exist, defaults to "false"
           create-repo: true
 

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -18,6 +18,13 @@ parameters:
       Setup and use CircleCI's remote Docker environment for Docker and
       docker-compose commands? Not required if using the default executor
 
+  remote-docker-version:
+    type: string
+    default: 17.09.0-ce
+    description: >
+      Allow custom docker version if using Docker engine.
+      Defaults to 17.09.0-ce
+
   profile-name:
     type: string
     default: "default"
@@ -136,7 +143,8 @@ steps:
   - when:
       condition: <<parameters.setup-remote-docker>>
       steps:
-        - setup_remote_docker
+        - setup_remote_docker:
+            version: <<parameters.remote-docker-version>>
 
   - ecr-login:
       profile-name: <<parameters.profile-name>>

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -90,6 +90,13 @@ parameters:
       Setup and use CircleCI's remote Docker environment for Docker and
       docker-compose commands? Not required if using the default executor
 
+  remote-docker-version:
+    type: string
+    default: 17.09.0-ce
+    description: >
+      Allow custom remote Docker version if using Docker engine.
+      Defaults to 17.09.0-ce
+
   dockerfile:
     type: string
     default: Dockerfile
@@ -122,6 +129,7 @@ steps:
   - build-and-push-image:
       profile-name: <<parameters.profile-name>>
       setup-remote-docker: <<parameters.setup-remote-docker>>
+      remote-docker-version: <<parameters.remote-docker-version>>
       aws-access-key-id: <<parameters.aws-access-key-id>>
       aws-secret-access-key: <<parameters.aws-secret-access-key>>
       region: <<parameters.region>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

https://support.circleci.com/hc/en-us/articles/360050934711

### Description

It adds `remote-docker-version` parameter to `build-and-push-image` job & command. It defaults to current CircleCI's default, `17.09.0-ce`.