### PR TITLE
[semver:minor] Option to enable docker layer caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ workflows:
           # when setup-remote-docker is true, customize docker engine version (default is `19.03.13`)
           remote-docker-version: 19.03.13
 
+          # set this to enable Docker layer caching if using remote Docker engine.
+          # defaults to "false"
+          remote-docker-layer-caching: true
+
           # set this to true to create the repository if it does not already exist, defaults to "false"
           create-repo: true
 

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -23,6 +23,13 @@ parameters:
     default: 19.03.13
     description: Specific remote docker version
 
+  remote-docker-layer-caching:
+    type: boolean
+    default: false
+    description: >
+      Enable Docker layer caching if using remote Docker engine.
+      Defaults to false.
+
   profile-name:
     type: string
     default: "default"
@@ -143,6 +150,7 @@ steps:
       steps:
         - setup_remote_docker:
             version: <<parameters.remote-docker-version>>
+            docker_layer_caching: <<parameters.remote-docker-layer-caching>>
 
   - ecr-login:
       profile-name: <<parameters.profile-name>>

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -95,6 +95,13 @@ parameters:
     default: 19.03.13
     description: Specific remote docker version
 
+  remote-docker-layer-caching:
+    type: boolean
+    default: false
+    description: >
+      Enable Docker layer caching if using remote Docker engine.
+      Defaults to false.
+
   dockerfile:
     type: string
     default: Dockerfile
@@ -128,6 +135,7 @@ steps:
       profile-name: <<parameters.profile-name>>
       setup-remote-docker: <<parameters.setup-remote-docker>>
       remote-docker-version: <<parameters.remote-docker-version>>
+      remote-docker-layer-caching: <<parameters.remote-docker-layer-caching>>
       aws-access-key-id: <<parameters.aws-access-key-id>>
       aws-secret-access-key: <<parameters.aws-secret-access-key>>
       region: <<parameters.region>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
Address feature in GitHub Issue #67 

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
Enable docker-layer-caching when using remote docker environment

Example:
```
      - aws-ecr/build-and-push-image:
          aws-access-key-id: AWS_ACCESS_KEY_ID
          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
          region: AWS_REGION
          account-url: ECR_ACCOUNT_URL
          repo: << parameters.repo >>
          setup-remote-docker: true
          remote-docker-layer-caching: true
          checkout: false
```