### PR TITLE
[semver:minor] add ability to create repo on push-image only

### DIFF
--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -159,13 +159,6 @@ steps:
       aws-access-key-id: <<parameters.aws-access-key-id>>
       aws-secret-access-key: <<parameters.aws-secret-access-key>>
 
-  - when:
-      condition: <<parameters.create-repo>>
-      steps:
-        - run: |
-            aws ecr describe-repositories --profile <<parameters.profile-name>> --region $<<parameters.region>> --repository-names <<parameters.repo>> > /dev/null 2>&1 || \
-            aws ecr create-repository --profile <<parameters.profile-name>> --region $<<parameters.region>> --repository-name <<parameters.repo>> --image-scanning-configuration scanOnPush=<<parameters.repo-scan-on-push>>
-
   - build-image:
       account-url: <<parameters.account-url>>
       repo: <<parameters.repo>>
@@ -184,3 +177,7 @@ steps:
       account-url: <<parameters.account-url>>
       repo: <<parameters.repo>>
       tag: <<parameters.tag>>
+      create-repo: <<parameters.create-repo>>
+      repo-scan-on-push: <<parameters.repo-scan-on-push>>
+      profile-name: <<parameters.profile-name>>
+      region: <<parameters.region>>

--- a/src/commands/push-image.yml
+++ b/src/commands/push-image.yml
@@ -18,7 +18,39 @@ parameters:
     type: string
     default: "latest"
 
+  create-repo:
+    type: boolean
+    default: false
+    description: Should the repo be created if it does not exist?
+
+  repo-scan-on-push:
+    type: boolean
+    default: true
+    description: Should the created repo be security scanned on push?
+
+  region:
+    type: env_var_name
+    default: AWS_REGION
+    description: >
+      Name of env var storing your AWS region information,
+      defaults to AWS_REGION. Only required when skip-when-tags-exist
+      or ecr-login are set to true.
+
+  profile-name:
+    type: string
+    default: "default"
+    description: >
+      AWS profile name to be configured. Only required when skip-when-tags-exist
+      or ecr-login are set to true.
+
 steps:
+  - when:
+      condition: <<parameters.create-repo>>
+      steps:
+        - run: |
+            aws ecr describe-repositories --profile <<parameters.profile-name>> --region $<<parameters.region>> --repository-names <<parameters.repo>> > /dev/null 2>&1 || \
+            aws ecr create-repository --profile <<parameters.profile-name>> --region $<<parameters.region>> --repository-name <<parameters.repo>> --image-scanning-configuration scanOnPush=<<parameters.repo-scan-on-push>>
+
   - run:
       name: Push image to Amazon ECR
       command: |


### PR DESCRIPTION
### Checklist

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

Currently, the `build-and-push-image` command (& job) allows to the create ECR repository if it does not exist.

Meanwhile, the separated `build-image`, `ecr-login` and `push-image` allow to decorrelate the different steps, in case we would like to orchestrate them differently, spread them around our pipeline, or simply only push the image after a successful test depending on the image being built.

That being said, it's not possible to have all the good stuff `build-and-push-image` is offering with such a split in different commands: **the `create-repo` part is cruelly missing and is only part of the `build-and-push-image` overarching command**.

### Description

This PR adds the `create-repo` capability to the `push-image` command.

Moreover, it also moves it away from the `build-and-push-image` logic, since it's now being delegated to the `push-image` command. The change in ordering during a `build-and-push-image` run with `skip-when-tags-exist` enabled (the repo creation being run after the `build-image` instead of before it) doesn't affect the `build-image` step in any way: if the repo already exist, the `create-step` wouldn't have done anything anyway, and if it doesn't already exist, if will anyway fail to find any existing tag.