### PR TITLE
[semver:minor] Setup Dockerhub authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ workflows:
           # defaults to "false"
           remote-docker-layer-caching: true
 
+          # set this to enable dockerhub authenticated pulls, defaults to false.
+          docker-login: true
+
+          # name of env var storing your dockerhub username, defaults to DOCKERHUB_USERNAME.
+          dockerhub-username: DOCKERHUB_USERNAME
+
+          # name of env var storing your dockerhub password, defaults to DOCKERHUB_PASSWORD.
+          dockerhub-password: DOCKERHUB_PASSWORD
+
           # set this to true to create the repository if it does not already exist, defaults to "false"
           create-repo: true
 

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -37,7 +37,7 @@ parameters:
       Enable dockerhub authentication. Defaults to false.
 
   dockerhub-username:
-    type: string
+    type: env_var_name
     default: DOCKERHUB_USERNAME
     description: >
       Dockerhub username to be configured. Set this to the name of
@@ -45,7 +45,7 @@ parameters:
       value, i.e. DOCKERHUB_USERNAME.
 
   dockerhub-password:
-    type: string
+    type: env_var_name
     default: DOCKERHUB_PASSWORD
     description: >
       Dockerhub password to be configured. Set this to the name of

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -30,6 +30,28 @@ parameters:
       Enable Docker layer caching if using remote Docker engine.
       Defaults to false.
 
+  docker-login:
+    type: boolean
+    default: false
+    description: >
+      Enable dockerhub authentication. Defaults to false.
+
+  dockerhub-username:
+    type: string
+    default: DOCKERHUB_USERNAME
+    description: >
+      Dockerhub username to be configured. Set this to the name of
+      the environment variable you will set to hold this
+      value, i.e. DOCKERHUB_USERNAME.
+
+  dockerhub-password:
+    type: string
+    default: DOCKERHUB_PASSWORD
+    description: >
+      Dockerhub password to be configured. Set this to the name of
+      the environment variable you will set to hold this
+      value, i.e. DOCKERHUB_PASSWORD.
+
   profile-name:
     type: string
     default: "default"
@@ -165,6 +187,12 @@ steps:
         - run: |
             aws ecr describe-repositories --profile <<parameters.profile-name>> --region $<<parameters.region>> --repository-names <<parameters.repo>> > /dev/null 2>&1 || \
             aws ecr create-repository --profile <<parameters.profile-name>> --region $<<parameters.region>> --repository-name <<parameters.repo>> --image-scanning-configuration scanOnPush=<<parameters.repo-scan-on-push>>
+
+  - when:
+      condition: <<parameters.docker-login>>
+      steps:
+        - run: |
+            docker login -u<<parameters.dockerhub-username>> -p<<parameters.dockerhub-password>>      
 
   - build-image:
       account-url: <<parameters.account-url>>

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -192,7 +192,7 @@ steps:
       condition: <<parameters.docker-login>>
       steps:
         - run: |
-            docker login -u<<parameters.dockerhub-username>> -p<<parameters.dockerhub-password>>      
+            docker login -u<<parameters.dockerhub-username>> -p<<parameters.dockerhub-password>>
 
   - build-image:
       account-url: <<parameters.account-url>>


### PR DESCRIPTION
### Checklist

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

To be able run a docker login command as part of the build-and-push-image job.

### Description

Example:

      - aws-ecr/build-and-push-image:
             aws-access-key-id: AWS_ACCESS_KEY_ID
             aws-secret-access-key: AWS_SECRET_ACCESS_KEY
             region: AWS_REGION
             repo: << parameters.repo >>
             create-repo: true
             docker-login: true