### PR TITLE
[semver:patch] Setup dockerhub authentication (update build-and-push-image job)

### DIFF
--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -102,6 +102,28 @@ parameters:
       Enable Docker layer caching if using remote Docker engine.
       Defaults to false.
 
+  docker-login:
+    type: boolean
+    default: false
+    description: >
+      Enable dockerhub authentication. Defaults to false.
+
+  dockerhub-username:
+    type: env_var_name
+    default: DOCKERHUB_USERNAME
+    description: >
+      Dockerhub username to be configured. Set this to the name of
+      the environment variable you will set to hold this
+      value, i.e. DOCKERHUB_USERNAME.
+
+  dockerhub-password:
+    type: env_var_name
+    default: DOCKERHUB_PASSWORD
+    description: >
+      Dockerhub password to be configured. Set this to the name of
+      the environment variable you will set to hold this
+      value, i.e. DOCKERHUB_PASSWORD.
+
   dockerfile:
     type: string
     default: Dockerfile
@@ -136,6 +158,9 @@ steps:
       setup-remote-docker: <<parameters.setup-remote-docker>>
       remote-docker-version: <<parameters.remote-docker-version>>
       remote-docker-layer-caching: <<parameters.remote-docker-layer-caching>>
+      docker-login: <<parameters.docker-login>>
+      dockerhub-username: <<parameters.dockerhub-username>>
+      dockerhub-password: <<parameters.dockerhub-password>>
       aws-access-key-id: <<parameters.aws-access-key-id>>
       aws-secret-access-key: <<parameters.aws-secret-access-key>>
       region: <<parameters.region>>


### PR DESCRIPTION
### Checklist

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

To be able run a docker login command as part of the build-and-push-image job.

### Description

Example usage:

    - aws-ecr/build-and-push-image:
        aws-access-key-id: AWS_ACCESS_KEY_ID
        aws-secret-access-key: AWS_SECRET_ACCESS_KEY
        region: AWS_REGION
        repo: << parameters.repo >>
        create-repo: true
        docker-login: true


The previous pull request was merged but it didn't solved the problem as i did't updade the actual build-and-push-image job. I just did the update on build-and-push-image command:
https://github.com/CircleCI-Public/aws-ecr-orb/pull/120