### PR TITLE
[semver:patch] Fix docker login command

### DIFF
--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -192,7 +192,7 @@ steps:
       condition: <<parameters.docker-login>>
       steps:
         - run: |
-            docker login -u<<parameters.dockerhub-username>> -p<<parameters.dockerhub-password>>
+            docker login -u $<<parameters.dockerhub-username>> -p $<<parameters.dockerhub-password>>
 
   - build-image:
       account-url: <<parameters.account-url>>


### PR DESCRIPTION
### Checklist

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

Fixing docker login command to be able to get the content of dockerhub-username and dockerhub-password variables.

### Description

Currently, the command is not able to do the variables substitution. It's only able to take the default or hardcoded values.