### PR TITLE
[semver:major] use standard AWS_DEFAULT_REGION for region variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ workflows:
           # name of env var storing your AWS Secret Access Key, defaults to AWS_SECRET_ACCESS_KEY
           aws-secret-access-key: SECRET_ACCESS_KEY_ENV_VAR_NAME
 
-          # name of env var storing your AWS region, defaults to AWS_REGION
-          region: AWS_REGION_ENV_VAR_NAME
+          # name of env var storing your AWS region, defaults to AWS_DEFAULT_REGION
+          region: AWS_DEFAULT_REGION_ENV_VAR_NAME
 
           # name of env var storing your ECR account URL, defaults to AWS_ECR_ACCOUNT_URL
           account-url: AWS_ECR_ACCOUNT_URL_ENV_VAR_NAME

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -75,10 +75,10 @@ parameters:
 
   region:
     type: env_var_name
-    default: AWS_REGION
+    default: AWS_DEFAULT_REGION
     description: >
       Name of env var storing your AWS region information,
-      defaults to AWS_REGION
+      defaults to AWS_DEFAULT_REGION
 
   account-url:
     type: env_var_name

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -116,7 +116,7 @@ steps:
         IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
         for tag in "${DOCKER_TAGS[@]}"; do
           if [ "<<parameters.skip-when-tags-exist>>" = "true" ]; then
-            docker_tag_exists_in_ecr=$(aws ecr describe-images --registry-id $registry_id --repository-name <<parameters.repo>> --query "contains(imageDetails[].imageTags[], '$tag')")
+            docker_tag_exists_in_ecr=$(aws ecr describe-images --profile <<parameters.profile-name>> --registry-id $registry_id --repository-name <<parameters.repo>> --query "contains(imageDetails[].imageTags[], '$tag')")
             if [ "$docker_tag_exists_in_ecr" = "true" ]; then
               docker pull $<<parameters.account-url>>/<<parameters.repo>>:${tag}
               let "number_of_tags_in_ecr+=1"

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -58,10 +58,10 @@ parameters:
 
   region:
     type: env_var_name
-    default: AWS_REGION
+    default: AWS_DEFAULT_REGION
     description: >
       Name of env var storing your AWS region information,
-      defaults to AWS_REGION. Only required when skip-when-tags-exist
+      defaults to AWS_DEFAULT_REGION. Only required when skip-when-tags-exist
       or ecr-login are set to true.
 
   profile-name:

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -11,10 +11,10 @@ parameters:
 
   region:
     type: env_var_name
-    default: AWS_REGION
+    default: AWS_DEFAULT_REGION
     description: >
       Name of env var storing your AWS region information,
-      defaults to AWS_REGION
+      defaults to AWS_DEFAULT_REGION
 
   profile-name:
     type: string

--- a/src/examples/simple-build-and-push.yml
+++ b/src/examples/simple-build-and-push.yml
@@ -24,8 +24,8 @@ usage:
             # name of env var storing your AWS Secret Access Key, defaults to AWS_SECRET_ACCESS_KEY
             aws-secret-access-key: SECRET_ACCESS_KEY_ENV_VAR_NAME
 
-            # name of env var storing your AWS region, defaults to AWS_REGION
-            region: AWS_REGION_ENV_VAR_NAME
+            # name of env var storing your AWS region, defaults to AWS_DEFAULT_REGION
+            region: AWS_DEFAULT_REGION_ENV_VAR_NAME
 
             # name of env var storing your ECR account URL, defaults to AWS_ECR_ACCOUNT_URL
             account-url: AWS_ECR_ACCOUNT_URL_ENV_VAR_NAME

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -36,10 +36,10 @@ parameters:
 
   region:
     type: env_var_name
-    default: AWS_REGION
+    default: AWS_DEFAULT_REGION
     description: >
       Name of env var storing your AWS region information,
-      defaults to AWS_REGION
+      defaults to AWS_DEFAULT_REGION
 
   account-url:
     type: env_var_name


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
Update standard environment variable for region to match the aws cli instead of the aws sdk.  
https://github.com/CircleCI-Public/aws-ecr-orb/issues/131
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
 I propose we use the standard environment variable AWS_DEFAULT_REGION in the ecr orb to match the standard environment variables used in the aws cli.
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
