### PR TITLE
Update Ubuntu SO version [semver:major]

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -7,4 +7,4 @@ display:
   source_url: https://github.com/CircleCI-Public/aws-ecr-orb
 
 orbs:
-  aws-cli: circleci/aws-cli@1.2
+  aws-cli: circleci/aws-cli@2.0.0

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -5,7 +5,7 @@ description: >
 parameters:
   image:
     type: string
-    default: ubuntu-1604:201903-01
+    default: ubuntu-2004:202101-01
   use-docker-layer-caching:
     type: boolean
     default: false

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -5,7 +5,7 @@ description: >
 parameters:
   image:
     type: string
-    default: ubuntu-2004:202101-01
+    default: ubuntu-2004:202010-01
   use-docker-layer-caching:
     type: boolean
     default: false


### PR DESCRIPTION
### 💡 Issue

We are receiving an error since some days ago by different users (you can check this PR: https://github.com/CircleCI-Public/aws-ecr-orb/issues/136).

### 📚 Description

I took the idea of upgrading the SO version from this [comment](https://github.com/CircleCI-Public/aws-ecr-orb/issues/134#issuecomment-814066142).

I propose to update the Ubuntu SO version from the 16.04 (`ubuntu-1604:201903-01`) to the 20.04 (`ubuntu-2004:202010-01`) as of this [doc CircleCI reference](https://circleci.com/docs/2.0/configuration-reference/#available-machine-images) mentions.

### 🔑 Extra

As I commented [here](https://github.com/CircleCI-Public/aws-ecr-orb/issues/136#issuecomment-814231506), applying directly this change in the `config.yml` file:
```yml
jobs:
  build-app:
    machine :
      image : ubuntu-2004:202010-01
    steps:
      #...
```

The CI worked again for two applications that were failing.
But, we have others who are working using `machine: true` without defining the SO 🤔 .

[Maybe is this related?](https://circleci.com/docs/2.0/configuration-reference/#available-machine-images)
> Note: Ubuntu 16.04 reaches the end of its LTS window at the end of April 2021 and will no longer be supported by Canonical. As a result, the final 16.04 CircleCI machine image release by us will take place in April to include the most recent security patches. We suggest upgrading to the Ubuntu 20.04 image for continued releases past April. 2021.
