### PR TITLE
use --password-stdin option on docker login

### DIFF
--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -192,7 +192,7 @@ steps:
       condition: <<parameters.docker-login>>
       steps:
         - run: |
-            docker login -u $<<parameters.dockerhub-username>> -p $<<parameters.dockerhub-password>>
+            echo <<parameters.dockerhub-password>> | docker login -u $<<parameters.dockerhub-username>> --password-stdin
 
   - build-image:
       account-url: <<parameters.account-url>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues
I believe it is better to remove this warning message on docker login.
```
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
``` 
issue: #138 
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
add `--password-stdin` option in docker login command.
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
