### PR TITLE
feat!: add support for pushing helm charts to ecr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,24 +55,24 @@ workflows:
           attach-workspace: true
           workspace-root: workspace
           profile-name: testing
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+          repo: aws-ecr-orb-helm-${CIRCLE_SHA1:0:7}-named-profile
           create-repo: true
           tag: integration
           path: sample/mychart
           post-steps:
-            - run: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile --force
+            - run: aws ecr delete-repository --repository-name aws-ecr-orb-helm-${CIRCLE_SHA1:0:7}-named-profile --force
           requires: [pre-integration]
 
       - aws-ecr/push-helm-chart:
           name: integration-tests-helm-chart-default-profile
           attach-workspace: true
           workspace-root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
+          repo: aws-ecr-orb-helm-${CIRCLE_SHA1:0:7}-default-profile
           create-repo: true
           tag: integration
           path: sample/mychart
           post-steps:
-            - run: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile --force
+            - run: aws ecr delete-repository --repository-name aws-ecr-orb-helm-${CIRCLE_SHA1:0:7}-default-profile --force
           requires: [pre-integration]
 
       - aws-ecr/build-and-push-image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,31 @@ workflows:
       - pre-integration-checkout-workspace-job:
           name: pre-integration
 
+      - aws-ecr/push-helm-chart:
+          name: integration-tests-helm-chart-named-profile
+          attach-workspace: true
+          workspace-root: workspace
+          profile-name: testing
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+          create-repo: true
+          tag: integration
+          path: workspace/sample/mychart
+          post-steps:
+            - run: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile --force
+          requires: [pre-integration]
+
+      - aws-ecr/push-helm-chart:
+          name: integration-tests-helm-chart-default-profile
+          attach-workspace: true
+          workspace-root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
+          create-repo: true
+          tag: integration
+          path: workspace/sample/mychart
+          post-steps:
+            - run: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile --force
+          requires: [pre-integration]
+      
       - aws-ecr/build-and-push-image:
           name: integration-tests-default-profile
           attach-workspace: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ workflows:
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
           create-repo: true
           tag: integration
-          path: workspace/sample/mychart
+          path: sample/mychart
           post-steps:
             - run: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile --force
           requires: [pre-integration]
@@ -70,7 +70,7 @@ workflows:
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
           create-repo: true
           tag: integration
-          path: workspace/sample/mychart
+          path: sample/mychart
           post-steps:
             - run: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile --force
           requires: [pre-integration]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ workflows:
           post-steps:
             - run: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile --force
           requires: [pre-integration]
-      
+
       - aws-ecr/build-and-push-image:
           name: integration-tests-default-profile
           attach-workspace: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,3 +156,5 @@ workflows:
             - integration-tests-default-profile
             - integration-tests-named-profile
             - integration-tests-skip-when-tags-exist
+            - integration-tests-helm-chart-default-profile
+            - integration-tests-helm-chart-named-profile

--- a/sample/mychart/.helmignore
+++ b/sample/mychart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/sample/mychart/Chart.yaml
+++ b/sample/mychart/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: mychart
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/sample/mychart/templates/configmap.yaml
+++ b/sample/mychart/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mychart-configmap
+data:
+  myvalue: "Hello World"

--- a/sample/mychart/values.yaml
+++ b/sample/mychart/values.yaml
@@ -1,0 +1,83 @@
+# Default values for mychart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+      - path: /
+        backend:
+          serviceName: chart-example.local
+          servicePort: 80
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,3 +8,4 @@ display:
 
 orbs:
   aws-cli: circleci/aws-cli@2.0.0
+  helm: circleci/helm@1.2.0

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -99,7 +99,7 @@ steps:
           - <<parameters.ecr-login>>
           - <<parameters.skip-when-tags-exist>>
       steps:
-        - ecr-login:
+        - docker-ecr-login:
             profile-name: <<parameters.profile-name>>
             region: <<parameters.region>>
             account-url: <<parameters.account-url>>

--- a/src/commands/docker-ecr-login.yml
+++ b/src/commands/docker-ecr-login.yml
@@ -1,0 +1,53 @@
+description: "Authenticate docker into the Amazon ECR service"
+
+parameters:
+  account-url:
+    type: env_var_name
+    default: AWS_ECR_ACCOUNT_URL
+    description: >
+      Env var storing Amazon ECR account URL that maps to an AWS account,
+      e.g. {awsAccountNum}.dkr.ecr.us-west-2.amazonaws.com
+      defaults to AWS_ECR_ACCOUNT_URL
+
+  region:
+    type: env_var_name
+    default: AWS_REGION
+    description: >
+      Name of env var storing your AWS region information,
+      defaults to AWS_REGION
+
+  profile-name:
+    type: string
+    default: "default"
+    description: >
+      AWS profile name to be configured.
+      defaults to "default"
+
+  aws-access-key-id:
+    type: env_var_name
+    default: AWS_ACCESS_KEY_ID
+    description: >
+      AWS access key id for IAM role. Set this to the name of
+      the environment variable you will set to hold this
+      value, i.e. AWS_ACCESS_KEY.
+
+  aws-secret-access-key:
+    type: env_var_name
+    default: AWS_SECRET_ACCESS_KEY
+    description: >
+      AWS secret key for IAM role. Set this to the name of
+      the environment variable you will set to hold this
+      value, i.e. AWS_SECRET_ACCESS_KEY.
+
+steps:
+  - aws-cli/setup:
+      profile-name: <<parameters.profile-name>>
+      aws-access-key-id: <<parameters.aws-access-key-id>>
+      aws-secret-access-key: <<parameters.aws-secret-access-key>>
+      aws-region: <<parameters.region>>
+
+  - run:
+      name: Log docker into Amazon ECR
+      command: |
+        # get-login-password returns a password that we pipe to the docker login command
+        aws ecr get-login-password --region $<<parameters.region>> --profile <<parameters.profile-name>> | docker login --username AWS --password-stdin $<<parameters.account-url>>

--- a/src/commands/helm-ecr-login.yml
+++ b/src/commands/helm-ecr-login.yml
@@ -38,13 +38,13 @@ parameters:
       AWS secret key for IAM role. Set this to the name of
       the environment variable you will set to hold this
       value, i.e. AWS_SECRET_ACCESS_KEY.
-  
+
   helm-version:
     type: string
     default: "v3.2.4"
     description: >
       Helm version to install, .e.g. v3.2.4.
-      
+
 steps:
 
   - aws-cli/setup:
@@ -57,7 +57,7 @@ steps:
   - run:
       name: Log helm into Amazon ECR
       command: |
-        export HELM_EXPERIMENTAL_OCI=1 
+        export HELM_EXPERIMENTAL_OCI=1
         # get-login-password returns a password that we pipe to the helm login command
         aws ecr get-login-password --region $<<parameters.region>> --profile <<parameters.profile-name>> | \
           helm registry login \

--- a/src/commands/helm-ecr-login.yml
+++ b/src/commands/helm-ecr-login.yml
@@ -1,4 +1,4 @@
-description: "Authenticate into the Amazon ECR service"
+description: "Authenticate helm into the Amazon ECR service"
 
 parameters:
   account-url:
@@ -38,16 +38,27 @@ parameters:
       AWS secret key for IAM role. Set this to the name of
       the environment variable you will set to hold this
       value, i.e. AWS_SECRET_ACCESS_KEY.
-
+  
+  helm-version:
+    type: string
+    default: "v3.2.4"
+    description: >
+      Helm version to install, .e.g. v3.2.4.
+      
 steps:
+
   - aws-cli/setup:
       profile-name: <<parameters.profile-name>>
       aws-access-key-id: <<parameters.aws-access-key-id>>
       aws-secret-access-key: <<parameters.aws-secret-access-key>>
       aws-region: <<parameters.region>>
-
+  - helm/install-helm-client:
+      version: <<parameters.helm-version>>
   - run:
-      name: Log into Amazon ECR
+      name: Log helm into Amazon ECR
       command: |
-        # get-login-password returns a password that we pipe to the docker login command
-        aws ecr get-login-password --region $<<parameters.region>> --profile <<parameters.profile-name>> | docker login --username AWS --password-stdin $<<parameters.account-url>>
+        export HELM_EXPERIMENTAL_OCI=1 
+        # get-login-password returns a password that we pipe to the helm login command
+        aws ecr get-login-password --region $<<parameters.region>> --profile <<parameters.profile-name>> | \
+          helm registry login \
+          --username AWS --password-stdin $<<parameters.account-url>>

--- a/src/commands/login-and-push-helm-chart.yml
+++ b/src/commands/login-and-push-helm-chart.yml
@@ -1,6 +1,6 @@
 description: >
-  Install AWS CLI, if needed, and configure. Log into Amazon ECR
-  and push image to repository. Requires environment variables
+  Install AWS CLI and Helm, if needed, and configure. Log into Amazon ECR
+  and push Helm chart to repository. Requires environment variables
   for AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. We recommend
   these be saved in a Project (https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project)
   or in Contexts (https://circleci.com/docs/2.0/contexts).
@@ -10,47 +10,6 @@ parameters:
     type: executor
     default: default
     description: executor to use for this job
-
-  setup-remote-docker:
-    type: boolean
-    default: false
-    description: >
-      Setup and use CircleCI's remote Docker environment for Docker and
-      docker-compose commands? Not required if using the default executor
-
-  remote-docker-version:
-    type: string
-    default: 19.03.13
-    description: Specific remote docker version
-
-  remote-docker-layer-caching:
-    type: boolean
-    default: false
-    description: >
-      Enable Docker layer caching if using remote Docker engine.
-      Defaults to false.
-
-  docker-login:
-    type: boolean
-    default: false
-    description: >
-      Enable dockerhub authentication. Defaults to false.
-
-  dockerhub-username:
-    type: env_var_name
-    default: DOCKERHUB_USERNAME
-    description: >
-      Dockerhub username to be configured. Set this to the name of
-      the environment variable you will set to hold this
-      value, i.e. DOCKERHUB_USERNAME.
-
-  dockerhub-password:
-    type: env_var_name
-    default: DOCKERHUB_PASSWORD
-    description: >
-      Dockerhub password to be configured. Set this to the name of
-      the environment variable you will set to hold this
-      value, i.e. DOCKERHUB_PASSWORD.
 
   profile-name:
     type: string
@@ -105,7 +64,7 @@ parameters:
   tag:
     type: string
     default: "latest"
-    description: A comma-separated string containing docker image tags to build and push (default = latest)
+    description: A string containing the Helm chart tag to push (default = latest)
 
   checkout:
     type: boolean
@@ -127,33 +86,10 @@ parameters:
       Workspace root path that is either an absolute path or a path relative
       to the working directory. Defaults to '.' (the working directory)
 
-  dockerfile:
-    type: string
-    default: Dockerfile
-    description: Name of dockerfile to use. Defaults to Dockerfile.
-
   path:
     type: string
     default: .
-    description: Path to the directory containing your Dockerfile and build context. Defaults to . (working directory).
-
-  extra-build-args:
-    type: string
-    default: ""
-    description: >
-      Extra flags to pass to docker build. For examples, see
-      https://docs.docker.com/engine/reference/commandline/build
-
-  no-output-timeout:
-    type: string
-    default: "10m"
-    description: >
-      The amount of time to allow the docker build command to run before timing out (default is `10m`)
-
-  skip-when-tags-exist:
-    type: boolean
-    default: false
-    description: Whether to skip image building if all specified tags already exist in ECR
+    description: Path to the directory containing your Helm chart and build context. Defaults to . (working directory).
 
 steps:
   - when:
@@ -167,14 +103,7 @@ steps:
         - attach_workspace:
             at: <<parameters.workspace-root>>
 
-  - when:
-      condition: <<parameters.setup-remote-docker>>
-      steps:
-        - setup_remote_docker:
-            version: <<parameters.remote-docker-version>>
-            docker_layer_caching: <<parameters.remote-docker-layer-caching>>
-
-  - docker-ecr-login:
+  - helm-ecr-login:
       profile-name: <<parameters.profile-name>>
       region: <<parameters.region>>
       account-url: <<parameters.account-url>>
@@ -188,27 +117,8 @@ steps:
             aws ecr describe-repositories --profile <<parameters.profile-name>> --region $<<parameters.region>> --repository-names <<parameters.repo>> > /dev/null 2>&1 || \
             aws ecr create-repository --profile <<parameters.profile-name>> --region $<<parameters.region>> --repository-name <<parameters.repo>> --image-scanning-configuration scanOnPush=<<parameters.repo-scan-on-push>>
 
-  - when:
-      condition: <<parameters.docker-login>>
-      steps:
-        - run: |
-            docker login -u $<<parameters.dockerhub-username>> -p $<<parameters.dockerhub-password>>
-
-  - build-image:
+  - push-helm-chart:
       account-url: <<parameters.account-url>>
       repo: <<parameters.repo>>
       tag: <<parameters.tag>>
-      dockerfile: <<parameters.dockerfile>>
       path: <<parameters.path>>
-      extra-build-args: <<parameters.extra-build-args>>
-      no-output-timeout: <<parameters.no-output-timeout>>
-      skip-when-tags-exist: <<parameters.skip-when-tags-exist>>
-      profile-name: <<parameters.profile-name>>
-      region: <<parameters.region>>
-      aws-access-key-id: <<parameters.aws-access-key-id>>
-      aws-secret-access-key: <<parameters.aws-secret-access-key>>
-
-  - push-image:
-      account-url: <<parameters.account-url>>
-      repo: <<parameters.repo>>
-      tag: <<parameters.tag>>

--- a/src/commands/push-helm-chart.yml
+++ b/src/commands/push-helm-chart.yml
@@ -17,7 +17,7 @@ parameters:
     type: string
     default: "latest"
     description: A string containing the Helm chart tag to push (default = latest)
-  
+
   helm-version:
     type: string
     default: "v3.2.4"
@@ -34,6 +34,6 @@ steps:
   - run:
       name: Push chart to Amazon ECR
       command: |
-        export HELM_EXPERIMENTAL_OCI=1 
+        export HELM_EXPERIMENTAL_OCI=1
         helm chart save <<parameters.path>> $<<parameters.account-url>>/<<parameters.repo>>:<<parameters.tag>>
         helm chart push $<<parameters.account-url>>/<<parameters.repo>>:<<parameters.tag>>

--- a/src/commands/push-helm-chart.yml
+++ b/src/commands/push-helm-chart.yml
@@ -1,0 +1,39 @@
+description: Push a helm chart to the Amazon ECR registry
+
+parameters:
+  account-url:
+    type: env_var_name
+    default: AWS_ECR_ACCOUNT_URL
+    description: >
+      Env var storing Amazon ECR account URL that maps to an AWS account,
+      e.g. {awsAccountNum}.dkr.ecr.us-west-2.amazonaws.com
+      defaults to AWS_ECR_ACCOUNT_URL
+
+  repo:
+    type: string
+    description: Name of an Amazon ECR repository
+
+  tag:
+    type: string
+    default: "latest"
+    description: A string containing the Helm chart tag to push (default = latest)
+  
+  helm-version:
+    type: string
+    default: "v3.2.4"
+    description: Helm version to install, .e.g. v3.2.4.
+
+  path:
+    type: string
+    default: .
+    description: Path to the directory containing your Helm chart and build context. Defaults to . (working directory).
+
+steps:
+  - helm/install-helm-client:
+      version: <<parameters.helm-version>>
+  - run:
+      name: Push chart to Amazon ECR
+      command: |
+        export HELM_EXPERIMENTAL_OCI=1 
+        helm chart save <<parameters.path>> $<<parameters.account-url>>/<<parameters.repo>>:<<parameters.tag>>
+        helm chart push $<<parameters.account-url>>/<<parameters.repo>>:<<parameters.tag>>

--- a/src/examples/simple-push-helm-chart.yml
+++ b/src/examples/simple-push-helm-chart.yml
@@ -1,0 +1,43 @@
+description: Log into AWS and push Helm Chart to Amazon ECR
+
+usage:
+  version: 2.1
+
+  orbs:
+    aws-ecr: circleci/aws-ecr@x.y.z
+
+  workflows:
+    build_and_push_image:
+      jobs:
+        # build and push image to ECR
+        - aws-ecr/build-and-push-image:
+
+            # required if any necessary secrets are stored via Contexts
+            context: myContext
+
+            # AWS profile name, defaults to "default"
+            profile-name: myProfileName
+
+            # name of env var storing your AWS Access Key ID, defaults to AWS_ACCESS_KEY_ID
+            aws-access-key-id: ACCESS_KEY_ID_ENV_VAR_NAME
+
+            # name of env var storing your AWS Secret Access Key, defaults to AWS_SECRET_ACCESS_KEY
+            aws-secret-access-key: SECRET_ACCESS_KEY_ENV_VAR_NAME
+
+            # name of env var storing your AWS region, defaults to AWS_REGION
+            region: AWS_REGION_ENV_VAR_NAME
+
+            # name of env var storing your ECR account URL, defaults to AWS_ECR_ACCOUNT_URL
+            account-url: AWS_ECR_ACCOUNT_URL_ENV_VAR_NAME
+
+            # name of your ECR repository
+            repo: myECRRepository
+
+            # set this to true to create the repository if it does not already exist, defaults to "false"
+            create-repo: true
+
+            # ECR helm chart tag, defaults to "latest"
+            tag: 1.0.0
+
+            # path to helm chart, defaults to . (working directory)
+            path: pathToMyHelmChart

--- a/src/jobs/push-helm-chart.yml
+++ b/src/jobs/push-helm-chart.yml
@@ -1,0 +1,104 @@
+description: >
+  Install AWS CLI and Helm, if needed, and configure. Log into Amazon ECR
+  and push helm chart to repository. Requires environment variables
+  for AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. We recommend
+  these be saved in a Project (https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project)
+  or in Contexts (https://circleci.com/docs/2.0/contexts).
+
+executor: <<parameters.executor>>
+
+parameters:
+  executor:
+    type: executor
+    default: default
+    description: executor to use for this job
+
+  profile-name:
+    type: string
+    default: "default"
+    description: AWS profile name to be configured.
+
+  aws-access-key-id:
+    type: env_var_name
+    default: AWS_ACCESS_KEY_ID
+    description: >
+      AWS access key id for IAM role. Set this to the name of
+      the environment variable you will set to hold this
+      value, i.e. AWS_ACCESS_KEY_ID.
+
+  aws-secret-access-key:
+    type: env_var_name
+    default: AWS_SECRET_ACCESS_KEY
+    description: >
+      AWS secret key for IAM role. Set this to the name of
+      the environment variable you will set to hold this
+      value, i.e. AWS_SECRET_ACCESS_KEY.
+
+  region:
+    type: env_var_name
+    default: AWS_REGION
+    description: >
+      Name of env var storing your AWS region information,
+      defaults to AWS_REGION
+
+  account-url:
+    type: env_var_name
+    default: AWS_ECR_ACCOUNT_URL
+    description: >
+      Env var storing Amazon ECR account URL that maps to an AWS account,
+      e.g. {awsAccountNum}.dkr.ecr.us-west-2.amazonaws.com
+      defaults to AWS_ECR_ACCOUNT_URL
+
+  repo:
+    type: string
+    description: Name of an Amazon ECR repository
+
+  create-repo:
+    type: boolean
+    default: false
+    description: Should the repo be created if it does not exist?
+
+  tag:
+    type: string
+    default: "latest"
+    description: A string containing helm chart tag to push (default = latest)
+
+  checkout:
+    type: boolean
+    default: true
+    description: >
+      Boolean for whether or not to checkout as a first step. Default is true.
+
+  attach-workspace:
+    type: boolean
+    default: false
+    description: >
+      Boolean for whether or not to attach to an existing workspace. Default
+      is false.
+
+  workspace-root:
+    type: string
+    default: "."
+    description: >
+      Workspace root path that is either an absolute path or a path relative
+      to the working directory. Defaults to '.' (the working directory)
+
+  path:
+    type: string
+    default: .
+    description: Path to the directory containing your Chart and build context. Defaults to . (working directory).
+
+steps:
+  - login-and-push-helm-chart:
+      profile-name: <<parameters.profile-name>>
+      aws-access-key-id: <<parameters.aws-access-key-id>>
+      aws-secret-access-key: <<parameters.aws-secret-access-key>>
+      region: <<parameters.region>>
+      account-url: <<parameters.account-url>>
+      repo: <<parameters.repo>>
+      create-repo: <<parameters.create-repo>>
+      tag: <<parameters.tag>>
+      checkout: <<parameters.checkout>>
+      attach-workspace: <<parameters.attach-workspace>>
+      workspace-root: <<parameters.workspace-root>>
+      path: <<parameters.path>>


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
ECR supports pushing helm charts, however this is not possible with this orb yet. 
This PR adds support to also push helm charts since we need to do it in our team.

### Description

I did a breaking change in this PR because I renamed the `ecr-login` command to `docker-ecr-login` in order to be able to separate it explicitly from the new command that I added for helm, named `helm-ecr-login`.
