### PR TITLE
Support awscli v1

### DIFF
--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -49,5 +49,11 @@ steps:
   - run:
       name: Log into Amazon ECR
       command: |
-        # get-login-password returns a password that we pipe to the docker login command
-        aws ecr get-login-password --region $<<parameters.region>> --profile <<parameters.profile-name>> | docker login --username AWS --password-stdin $<<parameters.account-url>>
+        # The older versions of awscli does not support the subcommand `get-login-password`
+        # Use get-login in that case
+        if aws ecr help | grep get-login-password &>/dev/null; then
+          # get-login-password returns a password that we pipe to the docker login command
+          aws ecr get-login-password --region $<<parameters.region>> --profile <<parameters.profile-name>> | docker login --username AWS --password-stdin $<<parameters.account-url>>
+        else
+          $(aws ecr get-login --no-include-email --region $<<parameters.region>> --profile <<parameters.profile-name>>)
+        fi


### PR DESCRIPTION
### Checklist
 
- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

The command `ecr-login` uses `aws ecs get-login-password`, but that subcommand does not exist in the older versions of awscli.
ref: https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login-password.html#description

It could also be possible to just ignore these versions, but the orb `circleci/aws-cli`, which this orb depends on, does not seem to check which version of awscli is installed.
ref: https://github.com/CircleCI-Public/aws-cli-orb/blob/master/src/scripts/install.sh#L3

Thus, it might be reasonable to support these versions too.

### Description

- Check if `get-login-password` is available
- If not, use `get-login` instead.