### PR TITLE
[semver:minor] New ssh key for tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ workflows:
           bot-user: orb-publisher
           fail-if-semver-not-indicated: true
           publish-version-tag: true
-          ssh-fingerprints: 54:b8:9b:79:74:29:3e:dd:95:52:4d:4b:e6:8b:38:f2
+          ssh-fingerprints: 6f:16:49:d2:97:35:10:43:bc:a6:3f:f8:62:89:1f:42
           filters:
             branches:
               only: master


### PR DESCRIPTION
Marking as a minor so previous commit (https://github.com/CircleCI-Public/aws-ecr-orb/commit/2c50edfcd8fcb0a3944a13b7ef9ddf38fa375dd9) is deployed correctly.