### PR TITLE
[semver:patch] Update aws-cli orb to 2.0.3

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -7,4 +7,4 @@ display:
   source_url: https://github.com/CircleCI-Public/aws-ecr-orb
 
 orbs:
-  aws-cli: circleci/aws-cli@2.0.0
+  aws-cli: circleci/aws-cli@2.0.3


### PR DESCRIPTION
### Checklist

- [x] ~All new jobs, commands, executors, parameters have descriptions~ n/a
- [x] ~Examples have been added for any significant new features~ n/a
- [x] ~README has been updated, if necessary~ n/a

### Motivation, issues

[Version 2.0.3 of the aws-cli orb](https://circleci.com/developer/orbs/orb/circleci/aws-cli?version=2.0.3) leaves the installer sitting in /tmp whereas [version 2.0.0](https://circleci.com/developer/orbs/orb/circleci/aws-cli?version=2.0.0) leaves it in the current working directory, preventing a checkout and/or dirtying the git working copy.

### Description

* Update to version 2.0.3 of the `aws-cli` orb
