### PR TITLE
fixed docker login with ecr

### DIFF
--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -50,4 +50,4 @@ steps:
       name: Log into Amazon ECR
       command: |
         # get-login-password returns a password that we pipe to the docker login command
-        aws ecr get-login-password --region $<<parameters.region>> --profile <<parameters.profile-name>> | docker login --username AWS --password-stdin $<<parameters.account-url>>
+        docker login -u AWS -p $(aws ecr get-login-password --region $<<parameters.region>>) $<<parameters.account-url>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x ] All new jobs, commands, executors, parameters have descriptions
- [x ] Examples have been added for any significant new features
- [x ] README has been updated, if necessary

### Motivation, issues

It solves this issue #163 An error occurred (UnrecognizedClientException) when calling the GetAuthorizationToken operation: The security token included in the request is invalid. Error: Cannot perform an interactive login from a non TTY device bug


<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
I added this command  docker login -u AWS -p $(aws ecr get-login-password --region $<<parameters.region>>) $<<parameters.account-url>> and it seems to be working just fine. I think the problem is either from the newest version of awscli or from docker itself 

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
