### PR TITLE
Add a command to tag remote image without pulling them

### DIFF
--- a/src/commands/tag-image.yml
+++ b/src/commands/tag-image.yml
@@ -11,6 +11,7 @@ parameters:
 
   target-tag:
     type: string
+    default: "latest"
     description: A comma-separated string containing docker image tags (default = latest)
 
 steps:
@@ -18,8 +19,7 @@ steps:
       name: Add <<parameters.target-tag>> tag to <<parameters.repo>>:<<parameters.source-tag>>
       command: |
         # pull the image manifest from ECR
-        MANIFEST=$(aws ecr batch-get-image --repository-name <<parameters.repo>> --image-ids imageTag=<<parameters.source-tag>> --query 'images[].imageManifest' --output text)
+        MANIFEST=$(aws ecr batch-get-image --repository-name "<<parameters.repo>>" --image-ids "imageTag=<<parameters.source-tag>>" --query 'images[].imageManifest' --output text)
         IFS="," read -ra ECR_TAGS \<<< "<< parameters.target-tag >>"
         for tag in "${ECR_TAGS[@]}"; do
-          aws ecr put-image --repository-name <<parameters.repo>> --image-tag ${tag} --image-manifest "$MANIFEST"
-        done
+          aws ecr put-image --repository-name "<<parameters.repo>>" --image-tag "${tag}" --image-manifest "$MANIFEST"

--- a/src/commands/tag-image.yml
+++ b/src/commands/tag-image.yml
@@ -1,0 +1,25 @@
+description: Add a tag to an existing published image
+
+parameters:
+  repo:
+    type: string
+    description: Name of an Amazon ECR repository
+
+  source-tag:
+    type: string
+    description: An existing Docker image tag
+
+  target-tag:
+    type: string
+    description: A comma-separated string containing docker image tags (default = latest)
+
+steps:
+  - run:
+      name: Add <<parameters.target-tag>> tag to <<parameters.repo>>:<<parameters.source-tag>>
+      command: |
+        # pull the image manifest from ECR
+        MANIFEST=$(aws ecr batch-get-image --repository-name <<parameters.repo>> --image-ids imageTag=<<parameters.source-tag>> --query 'images[].imageManifest' --output text)
+        IFS="," read -ra ECR_TAGS \<<< "<< parameters.target-tag >>"
+        for tag in "${ECR_TAGS[@]}"; do
+          aws ecr put-image --repository-name <<parameters.repo>> --image-tag ${tag} --image-manifest "$MANIFEST"
+        done

--- a/src/examples/simple-tag-remote-image.yml
+++ b/src/examples/simple-tag-remote-image.yml
@@ -1,0 +1,37 @@
+description: Log into AWS, publish remote tags for existing image
+
+usage:
+  version: 2.1
+
+  orbs:
+    aws-ecr: circleci/aws-ecr@x.y.z
+
+  jobs:
+    tag_ecr_image:
+      parameters:
+        repo:
+          type: string
+        source-tag:
+          type: string
+        target-tag:
+          type: string
+      steps:
+        - aws-ecr/login
+        - aws-ecr/tag-image:
+            # name of your ECR repository
+            repo: <<parameters.repo>>
+
+            # existing tag that has been pushed to the registry
+            source-tag: <<parameters.source-tag>>
+
+            # ECR image tags you want to push (comma separated string)
+            target-tag: <<parameters.target-tag>>
+
+  workflows:
+    build_and_push_image:
+      jobs:
+        # Tag ECR image with "latest" and "staging"
+        - tag_ecr_image:
+            repo: my-ecr/repository
+            source-tag: $CIRCLE_SHA1
+            target-tag: latest,staging


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

fix https://github.com/CircleCI-Public/aws-ecr-orb/issues/166
The idea is to be able to promote existing images to other environments adding tags to it, without having to pull, tag and push the image to the agent but using the `aws ecr` command line tool

### Description

Add a command to tag remote images without pulling them using the aws ecr command line
