### PR TITLE
Add a digest-path parameter to push commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ workflows:
 
           # Set the resource_class option on the executor, defaults to "medium"
           resource-class: medium
+
+          # Path to save the digest of pushed image
+          digest-path: /tmp/my_image_digest.txt
 ```
 
 ## Contributing

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -101,6 +101,11 @@ parameters:
     type: string
     default: "latest"
     description: A comma-separated string containing docker image tags to build and push (default = latest)
+  
+  digest-path:
+    type: string
+    default: ""
+    description: "The path to save the digest of the pushed image"
 
   checkout:
     type: boolean
@@ -209,3 +214,4 @@ steps:
       account-url: <<parameters.account-url>>
       repo: <<parameters.repo>>
       tag: <<parameters.tag>>
+      digest-path: <<parameters.digest-path>>

--- a/src/commands/push-image.yml
+++ b/src/commands/push-image.yml
@@ -18,6 +18,11 @@ parameters:
     type: string
     default: "latest"
 
+  digest-path:
+    type: string
+    default: ""
+    description: "The path to save the digest of the pushed image"
+
 steps:
   - run:
       name: Push image to Amazon ECR
@@ -25,4 +30,9 @@ steps:
         IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
         for tag in "${DOCKER_TAGS[@]}"; do
           docker push $<<parameters.account-url>>/<<parameters.repo>>:${tag}
+          
+          if [ -n "<<parameters.digest-path>>" ]; then
+            mkdir -p "$(dirname <<parameters.digest-path>>)"
+            docker image inspect --format="{{index .RepoDigests 0}}" 
+            $<<parameters.account-url>>/<<parameters.repo>>:${tag} > "<<parameters.digest-path>>"
         done

--- a/src/examples/simple-build-and-push.yml
+++ b/src/examples/simple-build-and-push.yml
@@ -45,6 +45,9 @@ usage:
             # path to Dockerfile, defaults to . (working directory)
             path: pathToMyDockerfile
 
+            # path to save the digest of the pushed image
+            digest-path: /tmp/my_image_digest.txt
+
             # The amount of time to allow the docker build command to run before timing out, defaults to "10m"
             no-output-timeout: 20m
 


### PR DESCRIPTION
(Picking up from closed PR 66 - https://github.com/CircleCI-Public/aws-ecr-orb/pull/66)

### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Docker images in a registry have an immutable identifier generated by
the registry using a hash of the image manifest. This is very useful
for identifying an exact image.

This digest is returned by the registry when an image is pushed and
added to the local image metadata by the docker engine, which is our
opportunity to save it.

See https://success.docker.com/article/images-tagging-vs-digests

### Description

Add the digest-path parameter to push-image and build-and-push-image commands.
This parameter can be used to save the digest of an image to a file.

Subsequent commands can read this file to use the digest. The contents of the file looks like:

`123456789662.dkr.ecr.eu-west-1.amazonaws.com/orb-test@sha256:9d2b250af5748cf8fb2c7e9a14aab830c251daa3f8f3bc787bd4a3e8c586f39a`
