### PR TITLE
Add role-arn param for ecr-login

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ workflows:
           # AWS profile name, defaults to "default"
           profile-name: myProfileName
 
+          # AWS role profile should assume
+          role-arn: arn:aws:iam::123456789:role/some-role
+
           # name of env var storing your AWS Access Key ID, defaults to AWS_ACCESS_KEY_ID
           aws-access-key-id: ACCESS_KEY_ID_ENV_VAR_NAME
 

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -52,6 +52,11 @@ parameters:
     default: "default"
     description: AWS profile name to be configured.
 
+  role-arn:
+    type: string
+    default: ""
+    description: Role ARN that the profile should take.
+
   aws-access-key-id:
     type: env_var_name
     default: AWS_ACCESS_KEY_ID
@@ -171,6 +176,7 @@ steps:
 
   - ecr-login:
       profile-name: <<parameters.profile-name>>
+      role-arn: <<parameters.role-arn>>
       region: <<parameters.region>>
       account-url: <<parameters.account-url>>
       aws-access-key-id: <<parameters.aws-access-key-id>>

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -71,6 +71,13 @@ parameters:
       AWS profile name to be configured. Only required when skip-when-tags-exist
       or ecr-login are set to true.
 
+  role-arn:
+    type: string
+    default: ""
+    description: >
+      Role ARN that the profile should take. Only required when
+      skip-when-tags-exist or ecr-login are set to true.
+
   aws-access-key-id:
     type: env_var_name
     default: AWS_ACCESS_KEY_ID
@@ -101,6 +108,7 @@ steps:
       steps:
         - ecr-login:
             profile-name: <<parameters.profile-name>>
+            role-arn: <<parameters.role-arn>>
             region: <<parameters.region>>
             account-url: <<parameters.account-url>>
             aws-access-key-id: <<parameters.aws-access-key-id>>

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -23,6 +23,12 @@ parameters:
       AWS profile name to be configured.
       defaults to "default"
 
+  role-arn:
+    type: string
+    default: ""
+    description: >
+      Role ARN that the profile should take.
+
   aws-access-key-id:
     type: env_var_name
     default: AWS_ACCESS_KEY_ID
@@ -42,6 +48,7 @@ parameters:
 steps:
   - aws-cli/setup:
       profile-name: <<parameters.profile-name>>
+      role-arn: <<parameters.role-arn>>
       aws-access-key-id: <<parameters.aws-access-key-id>>
       aws-secret-access-key: <<parameters.aws-secret-access-key>>
       aws-region: <<parameters.region>>

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -18,6 +18,11 @@ parameters:
     default: "default"
     description: AWS profile name to be configured.
 
+  role-arn:
+    type: string
+    default: ""
+    description: Role ARN that the profile should take.
+
   aws-access-key-id:
     type: env_var_name
     default: AWS_ACCESS_KEY_ID
@@ -155,6 +160,7 @@ parameters:
 steps:
   - build-and-push-image:
       profile-name: <<parameters.profile-name>>
+      role-arn: <<parameters.role-arn>>
       setup-remote-docker: <<parameters.setup-remote-docker>>
       remote-docker-version: <<parameters.remote-docker-version>>
       remote-docker-layer-caching: <<parameters.remote-docker-layer-caching>>


### PR DESCRIPTION
### Checklist


- [x] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

Adds a `role-arn` parameter to the `ecr-login` command to support STS role-assumption. This param is already supported in the `setup` command of the `circleci/aws-cli` orb it simply hasn't been exposed as part of `ecr-login` yet.

https://github.com/CircleCI-Public/aws-ecr-orb/issues/158

### Description

Add `role-arn` parameter to `ecr-login` command which is then passed to the `aws-cli/setup` command.

Add `role-arn` parameter to the `build-image` command which is then passed to the `ecr-login` command.

Add `role-arn` parameter to the `build-and-push-image` command which is then passed to the `ecr-login` command.

Add `role-arn` parameter to the `build-and-push-image` job which is then passed to the `build-and-push-image` command.