### PR TITLE
Pass extra build arg params directly

### DIFF
--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -37,10 +37,6 @@ if [ "${PARAM_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${PARAM_SKIP_WHEN_TAGS_EXIST
     set -- "$@" --push
   fi
 
-  if [ -n "$PARAM_EXTRA_BUILD_ARGS" ]; then
-    set -- "$@" "${PARAM_EXTRA_BUILD_ARGS}"
-  fi
-
   if [ "${PARAM_PUBLIC_REGISTRY}" == "1" ]; then
     docker buildx build \
       -f "${PARAM_PATH}"/"${PARAM_DOCKERFILE}" \
@@ -59,6 +55,7 @@ if [ "${PARAM_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${PARAM_SKIP_WHEN_TAGS_EXIST
       --platform "${PARAM_PLATFORM}" \
       --progress plain \
       "$@" \
+      ${PARAM_EXTRA_BUILD_ARGS} \
       "${PARAM_PATH}"
   fi
 fi


### PR DESCRIPTION
### Motivation, issues

Fixes #182 

### Description
Instead of adding extra build args to $@, just pass them on the command line
