### PR TITLE
feat: update v8.1.0

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -69,6 +69,8 @@ workflows:
           workspace-root: workspace
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry
           create-repo: true
+          # role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          # profile-name: "OIDC-User"
           context: [CPE_ORBS_AWS]
           tag: integration,myECRRepoTag
           dockerfile: sample/Dockerfile

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -76,128 +76,128 @@ workflows:
               only: /.*/
           requires: [pre-integration]
 
-      # - aws-ecr/build-and-push-image:
-      #     name: integration-tests-pubic-registry
-      #     attach-workspace: true
-      #     workspace-root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry
-      #     create-repo: true
-      #     role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     region: "us-west-2"
-      #     assume-web-identity: true
-      #     profile-name: "OIDC-User"
-      #     context: [CPE-OIDC] 
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     extra-build-args: --compress
-      #     executor: amd64
-      #     public-registry: true
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry --force
-      #     platform: linux/amd64
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      #     requires: [pre-integration]
+      - aws-ecr/build-and-push-image:
+          name: integration-tests-pubic-registry
+          attach-workspace: true
+          workspace-root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry
+          create-repo: true
+          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          region: "us-west-2"
+          assume-web-identity: true
+          profile-name: "OIDC-User"
+          context: [CPE-OIDC] 
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra-build-args: --compress
+          executor: amd64
+          public-registry: true
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry --force
+          platform: linux/amd64
+          filters:
+            tags:
+              only: /.*/
+          requires: [pre-integration]
 
-      # - aws-ecr/build-and-push-image:
-      #     name: integration-tests-named-profile
-      #     attach-workspace: true
-      #     role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     region: "us-west-2"
-      #     assume-web-identity: true
-      #     profile-name: "OIDC-User"
-      #     context: [CPE-OIDC] 
-      #     workspace-root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-      #     create-repo: true
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     extra-build-args: --compress
-      #     executor: amd64
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      #     requires: [pre-integration]
+      - aws-ecr/build-and-push-image:
+          name: integration-tests-named-profile
+          attach-workspace: true
+          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          region: "us-west-2"
+          assume-web-identity: true
+          profile-name: "OIDC-User"
+          context: [CPE-OIDC] 
+          workspace-root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+          create-repo: true
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra-build-args: --compress
+          executor: amd64
+          filters:
+            tags:
+              only: /.*/
+          requires: [pre-integration]
 
-      # - tag-ecr-image:
-      #     name: integration-tests-tag-existing-image
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-      #     role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     region: "us-west-2"
-      #     assume-web-identity: true
-      #     profile-name: "OIDC-User"
-      #     context: [CPE-OIDC] 
-      #     source-tag: integration
-      #     target-tag: latest
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile --force
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      #     requires:
-      #       - integration-tests-named-profile
+      - tag-ecr-image:
+          name: integration-tests-tag-existing-image
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          region: "us-west-2"
+          assume-web-identity: true
+          profile-name: "OIDC-User"
+          context: [CPE-OIDC] 
+          source-tag: integration
+          target-tag: latest
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile --force
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - integration-tests-named-profile
 
-      # - aws-ecr/build-and-push-image:
-      #     name: integration-tests-skip-when-tags-exist-populate-image-<<matrix.executor>>
-      #     attach-workspace: true
-      #     role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     region: "us-west-2"
-      #     assume-web-identity: true
-      #     profile-name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     workspace-root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
-      #     create-repo: true
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     extra-build-args: --compress
-      #     skip-when-tags-exist: true
-      #     matrix:
-      #       parameters:
-      #         executor: ["amd64", "arm64"]
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      #     requires: [pre-integration]
+      - aws-ecr/build-and-push-image:
+          name: integration-tests-skip-when-tags-exist-populate-image-<<matrix.executor>>
+          attach-workspace: true
+          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          region: "us-west-2"
+          assume-web-identity: true
+          profile-name: "OIDC-User"
+          context: [CPE-OIDC]
+          workspace-root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
+          create-repo: true
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra-build-args: --compress
+          skip-when-tags-exist: true
+          matrix:
+            parameters:
+              executor: ["amd64", "arm64"]
+          filters:
+            tags:
+              only: /.*/
+          requires: [pre-integration]
 
-      # - aws-ecr/build-and-push-image:
-      #     name: integration-tests-skip-when-tags-exist-<<matrix.executor>>
-      #     attach-workspace: true
-      #     role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     region: "us-west-2"
-      #     assume-web-identity: true
-      #     profile-name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     workspace-root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     extra-build-args: --compress
-      #     skip-when-tags-exist: true
-      #     aws-cli-version: 2.4.10
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: |
-      #             aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>> --force
-      #     matrix:
-      #       parameters:
-      #         executor: ["amd64", "arm64"]
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      #     requires:
-      #       - integration-tests-skip-when-tags-exist-populate-image-amd64
-      #       - integration-tests-skip-when-tags-exist-populate-image-arm64
+      - aws-ecr/build-and-push-image:
+          name: integration-tests-skip-when-tags-exist-<<matrix.executor>>
+          attach-workspace: true
+          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          region: "us-west-2"
+          assume-web-identity: true
+          profile-name: "OIDC-User"
+          context: [CPE-OIDC]
+          workspace-root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra-build-args: --compress
+          skip-when-tags-exist: true
+          aws-cli-version: 2.4.10
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: |
+                  aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>> --force
+          matrix:
+            parameters:
+              executor: ["amd64", "arm64"]
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - integration-tests-skip-when-tags-exist-populate-image-amd64
+            - integration-tests-skip-when-tags-exist-populate-image-arm64
 
       - orb-tools/lint:
           filters:
@@ -220,11 +220,11 @@ workflows:
             - orb-tools/review
             - orb-tools/pack
             - integration-tests-default-profile
-            # - integration-tests-pubic-registry
-            # - integration-tests-skip-when-tags-exist-amd64
-            # - integration-tests-skip-when-tags-exist-arm64
-            # - integration-tests-named-profile
-            # - integration-tests-tag-existing-image
+            - integration-tests-pubic-registry
+            - integration-tests-skip-when-tags-exist-amd64
+            - integration-tests-skip-when-tags-exist-arm64
+            - integration-tests-named-profile
+            - integration-tests-tag-existing-image
           github-token: GHI_TOKEN          
           context: orb-publisher
           filters:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -28,11 +28,15 @@ jobs:
         type: string
       profile-name:
         type: string
+      assume-web-identity:
+        type: boolean
+        default: false
     steps:
       - aws-ecr/ecr-login:
           profile-name: <<parameters.profile-name>>
           role-arn: <<parameters.role-arn>>
           region: <<parameters.region>>
+          assume-web-identity: <<parameters.assume-web-identity>>
       - aws-ecr/tag-image:
           repo: <<parameters.repo>>
           source-tag: <<parameters.source-tag>>
@@ -72,128 +76,128 @@ workflows:
               only: /.*/
           requires: [pre-integration]
 
-      - aws-ecr/build-and-push-image:
-          name: integration-tests-pubic-registry
-          attach-workspace: true
-          workspace-root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry
-          create-repo: true
-          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          region: "us-west-2"
-          assume-web-identity: true
-          profile-name: "OIDC-User"
-          context: [CPE-OIDC] 
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra-build-args: --compress
-          executor: amd64
-          public-registry: true
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry --force
-          platform: linux/amd64
-          filters:
-            tags:
-              only: /.*/
-          requires: [pre-integration]
+      # - aws-ecr/build-and-push-image:
+      #     name: integration-tests-pubic-registry
+      #     attach-workspace: true
+      #     workspace-root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry
+      #     create-repo: true
+      #     role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     region: "us-west-2"
+      #     assume-web-identity: true
+      #     profile-name: "OIDC-User"
+      #     context: [CPE-OIDC] 
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra-build-args: --compress
+      #     executor: amd64
+      #     public-registry: true
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry --force
+      #     platform: linux/amd64
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #     requires: [pre-integration]
 
-      - aws-ecr/build-and-push-image:
-          name: integration-tests-named-profile
-          attach-workspace: true
-          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          region: "us-west-2"
-          assume-web-identity: true
-          profile-name: "OIDC-User"
-          context: [CPE-OIDC] 
-          workspace-root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-          create-repo: true
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra-build-args: --compress
-          executor: amd64
-          filters:
-            tags:
-              only: /.*/
-          requires: [pre-integration]
+      # - aws-ecr/build-and-push-image:
+      #     name: integration-tests-named-profile
+      #     attach-workspace: true
+      #     role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     region: "us-west-2"
+      #     assume-web-identity: true
+      #     profile-name: "OIDC-User"
+      #     context: [CPE-OIDC] 
+      #     workspace-root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+      #     create-repo: true
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra-build-args: --compress
+      #     executor: amd64
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #     requires: [pre-integration]
 
-      - tag-ecr-image:
-          name: integration-tests-tag-existing-image
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          region: "us-west-2"
-          assume-web-identity: true
-          profile-name: "OIDC-User"
-          context: [CPE-OIDC] 
-          source-tag: integration
-          target-tag: latest
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile --force
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - integration-tests-named-profile
+      # - tag-ecr-image:
+      #     name: integration-tests-tag-existing-image
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+      #     role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     region: "us-west-2"
+      #     assume-web-identity: true
+      #     profile-name: "OIDC-User"
+      #     context: [CPE-OIDC] 
+      #     source-tag: integration
+      #     target-tag: latest
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile --force
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #     requires:
+      #       - integration-tests-named-profile
 
-      - aws-ecr/build-and-push-image:
-          name: integration-tests-skip-when-tags-exist-populate-image-<<matrix.executor>>
-          attach-workspace: true
-          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          region: "us-west-2"
-          assume-web-identity: true
-          profile-name: "OIDC-User"
-          context: [CPE-OIDC]
-          workspace-root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
-          create-repo: true
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra-build-args: --compress
-          skip-when-tags-exist: true
-          matrix:
-            parameters:
-              executor: ["amd64", "arm64"]
-          filters:
-            tags:
-              only: /.*/
-          requires: [pre-integration]
+      # - aws-ecr/build-and-push-image:
+      #     name: integration-tests-skip-when-tags-exist-populate-image-<<matrix.executor>>
+      #     attach-workspace: true
+      #     role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     region: "us-west-2"
+      #     assume-web-identity: true
+      #     profile-name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     workspace-root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
+      #     create-repo: true
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra-build-args: --compress
+      #     skip-when-tags-exist: true
+      #     matrix:
+      #       parameters:
+      #         executor: ["amd64", "arm64"]
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #     requires: [pre-integration]
 
-      - aws-ecr/build-and-push-image:
-          name: integration-tests-skip-when-tags-exist-<<matrix.executor>>
-          attach-workspace: true
-          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          region: "us-west-2"
-          assume-web-identity: true
-          profile-name: "OIDC-User"
-          context: [CPE-OIDC]
-          workspace-root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra-build-args: --compress
-          skip-when-tags-exist: true
-          aws-cli-version: 2.4.10
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: |
-                  aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>> --force
-          matrix:
-            parameters:
-              executor: ["amd64", "arm64"]
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - integration-tests-skip-when-tags-exist-populate-image-amd64
-            - integration-tests-skip-when-tags-exist-populate-image-arm64
+      # - aws-ecr/build-and-push-image:
+      #     name: integration-tests-skip-when-tags-exist-<<matrix.executor>>
+      #     attach-workspace: true
+      #     role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     region: "us-west-2"
+      #     assume-web-identity: true
+      #     profile-name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     workspace-root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra-build-args: --compress
+      #     skip-when-tags-exist: true
+      #     aws-cli-version: 2.4.10
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: |
+      #             aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>> --force
+      #     matrix:
+      #       parameters:
+      #         executor: ["amd64", "arm64"]
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #     requires:
+      #       - integration-tests-skip-when-tags-exist-populate-image-amd64
+      #       - integration-tests-skip-when-tags-exist-populate-image-arm64
 
       - orb-tools/lint:
           filters:
@@ -216,11 +220,11 @@ workflows:
             - orb-tools/review
             - orb-tools/pack
             - integration-tests-default-profile
-            - integration-tests-pubic-registry
-            - integration-tests-skip-when-tags-exist-amd64
-            - integration-tests-skip-when-tags-exist-arm64
-            - integration-tests-named-profile
-            - integration-tests-tag-existing-image
+            # - integration-tests-pubic-registry
+            # - integration-tests-skip-when-tags-exist-amd64
+            # - integration-tests-skip-when-tags-exist-arm64
+            # - integration-tests-named-profile
+            # - integration-tests-tag-existing-image
           github-token: GHI_TOKEN          
           context: orb-publisher
           filters:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -37,31 +37,31 @@ workflows:
             tags:
               only: /.*/
 
-      - aws-ecr/build-and-push-image:
-          name: integration-tests-default-profile
-          attach-workspace: true
-          workspace-root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
-          create-repo: true
-          context: [CPE_ORBS_AWS]
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra-build-args: --compress
-          executor: amd64
-          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_ADMIN
-          source-profile: default
-          new-profile-name: assume-role-test
-          lifecycle-policy-path: ./sample/policy.json
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile --force
-          platform: linux/amd64,linux/arm64
-          filters:
-            tags:
-              only: /.*/
-          requires: [pre-integration]
+      # - aws-ecr/build-and-push-image:
+      #     name: integration-tests-default-profile
+      #     attach-workspace: true
+      #     workspace-root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
+      #     create-repo: true
+      #     context: [CPE_ORBS_AWS]
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra-build-args: --compress
+      #     executor: amd64
+      #     role-arn: arn:aws:iam::122211685980:role/CPE_ECR_ADMIN
+      #     source-profile: default
+      #     new-profile-name: assume-role-test
+      #     lifecycle-policy-path: ./sample/policy.json
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile --force
+      #     platform: linux/amd64,linux/arm64
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #     requires: [pre-integration]
 
       - aws-ecr/build-and-push-image:
           name: integration-tests-pubic-registry
@@ -69,9 +69,10 @@ workflows:
           workspace-root: workspace
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry
           create-repo: true
-          # role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          # profile-name: "OIDC-User"
-          context: [CPE_ORBS_AWS]
+          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          region: "us-west-2"
+          profile-name: "OIDC-User"
+          context: [CPE-OIDC] 
           tag: integration,myECRRepoTag
           dockerfile: sample/Dockerfile
           path: workspace
@@ -88,89 +89,89 @@ workflows:
               only: /.*/
           requires: [pre-integration]
 
-      - aws-ecr/build-and-push-image:
-          name: integration-tests-named-profile
-          attach-workspace: true
-          context: [CPE_ORBS_AWS]
-          workspace-root: workspace
-          profile-name: testing
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-          create-repo: true
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra-build-args: --compress
-          region: ${AWS_REGION}
-          executor: amd64
-          filters:
-            tags:
-              only: /.*/
-          requires: [pre-integration]
+      # - aws-ecr/build-and-push-image:
+      #     name: integration-tests-named-profile
+      #     attach-workspace: true
+      #     context: [CPE_ORBS_AWS]
+      #     workspace-root: workspace
+      #     profile-name: testing
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+      #     create-repo: true
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra-build-args: --compress
+      #     region: ${AWS_REGION}
+      #     executor: amd64
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #     requires: [pre-integration]
 
-      - tag-ecr-image:
-          name: integration-tests-tag-existing-image
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-          context: [CPE_ORBS_AWS]
-          source-tag: integration
-          target-tag: latest
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile --force
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - integration-tests-named-profile
+      # - tag-ecr-image:
+      #     name: integration-tests-tag-existing-image
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+      #     context: [CPE_ORBS_AWS]
+      #     source-tag: integration
+      #     target-tag: latest
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile --force
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #     requires:
+      #       - integration-tests-named-profile
 
-      - aws-ecr/build-and-push-image:
-          name: integration-tests-skip-when-tags-exist-populate-image-<<matrix.executor>>
-          attach-workspace: true
-          context: [CPE_ORBS_AWS]
-          workspace-root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
-          create-repo: true
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra-build-args: --compress
-          skip-when-tags-exist: true
-          region: ${AWS_REGION}
-          matrix:
-            parameters:
-              executor: ["amd64", "arm64"]
-          filters:
-            tags:
-              only: /.*/
-          requires: [pre-integration]
+      # - aws-ecr/build-and-push-image:
+      #     name: integration-tests-skip-when-tags-exist-populate-image-<<matrix.executor>>
+      #     attach-workspace: true
+      #     context: [CPE_ORBS_AWS]
+      #     workspace-root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
+      #     create-repo: true
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra-build-args: --compress
+      #     skip-when-tags-exist: true
+      #     region: ${AWS_REGION}
+      #     matrix:
+      #       parameters:
+      #         executor: ["amd64", "arm64"]
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #     requires: [pre-integration]
 
-      - aws-ecr/build-and-push-image:
-          name: integration-tests-skip-when-tags-exist-<<matrix.executor>>
-          attach-workspace: true
-          context: [CPE_ORBS_AWS]
-          workspace-root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra-build-args: --compress
-          skip-when-tags-exist: true
-          aws-cli-version: 2.4.10
-          region: ${AWS_REGION}
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: |
-                  aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>> --force
-          matrix:
-            parameters:
-              executor: ["amd64", "arm64"]
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - integration-tests-skip-when-tags-exist-populate-image-amd64
-            - integration-tests-skip-when-tags-exist-populate-image-arm64
+      # - aws-ecr/build-and-push-image:
+      #     name: integration-tests-skip-when-tags-exist-<<matrix.executor>>
+      #     attach-workspace: true
+      #     context: [CPE_ORBS_AWS]
+      #     workspace-root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra-build-args: --compress
+      #     skip-when-tags-exist: true
+      #     aws-cli-version: 2.4.10
+      #     region: ${AWS_REGION}
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: |
+      #             aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>> --force
+      #     matrix:
+      #       parameters:
+      #         executor: ["amd64", "arm64"]
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #     requires:
+      #       - integration-tests-skip-when-tags-exist-populate-image-amd64
+      #       - integration-tests-skip-when-tags-exist-populate-image-arm64
 
       - orb-tools/lint:
           filters:
@@ -192,12 +193,12 @@ workflows:
             - orb-tools/lint
             - orb-tools/review
             - orb-tools/pack
-            - integration-tests-default-profile
+            # - integration-tests-default-profile
             - integration-tests-pubic-registry
-            - integration-tests-skip-when-tags-exist-amd64
-            - integration-tests-skip-when-tags-exist-arm64
-            - integration-tests-named-profile
-            - integration-tests-tag-existing-image
+            # - integration-tests-skip-when-tags-exist-amd64
+            # - integration-tests-skip-when-tags-exist-arm64
+            # - integration-tests-named-profile
+            # - integration-tests-tag-existing-image
           github-token: GHI_TOKEN          
           context: orb-publisher
           filters:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -190,11 +190,11 @@ workflows:
             - orb-tools/review
             - orb-tools/pack
             - integration-tests-default-profile
-            # - integration-tests-pubic-registry
-            # - integration-tests-skip-when-tags-exist-amd64
-            # - integration-tests-skip-when-tags-exist-arm64
-            # - integration-tests-named-profile
-            # - integration-tests-tag-existing-image
+            - integration-tests-pubic-registry
+            - integration-tests-skip-when-tags-exist-amd64
+            - integration-tests-skip-when-tags-exist-arm64
+            - integration-tests-named-profile
+            - integration-tests-tag-existing-image
           github-token: GHI_TOKEN          
           context: orb-publisher
           filters:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -86,7 +86,7 @@ workflows:
           region: "us-west-2"
           assume-web-identity: true
           profile-name: "OIDC-User"
-          context: [CPE-OIDC] 
+          context: [CPE-OIDC]
           tag: integration,myECRRepoTag
           dockerfile: sample/Dockerfile
           path: workspace
@@ -110,7 +110,7 @@ workflows:
           region: "us-west-2"
           assume-web-identity: true
           profile-name: "OIDC-User"
-          context: [CPE-OIDC] 
+          context: [CPE-OIDC]
           workspace-root: workspace
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
           create-repo: true
@@ -131,7 +131,7 @@ workflows:
           region: "us-west-2"
           assume-web-identity: true
           profile-name: "OIDC-User"
-          context: [CPE-OIDC] 
+          context: [CPE-OIDC]
           source-tag: integration
           target-tag: latest
           post-steps:
@@ -225,7 +225,7 @@ workflows:
             - integration-tests-skip-when-tags-exist-arm64
             - integration-tests-named-profile
             - integration-tests-tag-existing-image
-          github-token: GHI_TOKEN          
+          github-token: GHI_TOKEN
           context: orb-publisher
           filters:
             branches:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -52,6 +52,7 @@ workflows:
           role-arn: arn:aws:iam::122211685980:role/CPE_ECR_ADMIN
           source-profile: default
           new-profile-name: assume-role-test
+          lifecycle-policy-path: ./sample/policy.json
           post-steps:
             - run:
                 name: "Delete repository"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -49,6 +49,9 @@ workflows:
           path: workspace
           extra-build-args: --compress
           executor: amd64
+          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_ADMIN
+          source-profile: default
+          new-profile-name: assume-role-test
           post-steps:
             - run:
                 name: "Delete repository"
@@ -187,11 +190,11 @@ workflows:
             - orb-tools/review
             - orb-tools/pack
             - integration-tests-default-profile
-            - integration-tests-pubic-registry
-            - integration-tests-skip-when-tags-exist-amd64
-            - integration-tests-skip-when-tags-exist-arm64
-            - integration-tests-named-profile
-            - integration-tests-tag-existing-image
+            # - integration-tests-pubic-registry
+            # - integration-tests-skip-when-tags-exist-amd64
+            # - integration-tests-skip-when-tags-exist-arm64
+            # - integration-tests-named-profile
+            # - integration-tests-tag-existing-image
           github-token: GHI_TOKEN          
           context: orb-publisher
           filters:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -22,8 +22,17 @@ jobs:
         type: string
       target-tag:
         type: string
+      role-arn:
+        type: string
+      region:
+        type: string
+      profile-name:
+        type: string
     steps:
-      - aws-ecr/ecr-login
+      - aws-ecr/ecr-login:
+          profile-name: <<parameters.profile-name>>
+          role-arn: <<parameters.role-arn>>
+          region: <<parameters.region>>
       - aws-ecr/tag-image:
           repo: <<parameters.repo>>
           source-tag: <<parameters.source-tag>>
@@ -37,31 +46,31 @@ workflows:
             tags:
               only: /.*/
 
-      # - aws-ecr/build-and-push-image:
-      #     name: integration-tests-default-profile
-      #     attach-workspace: true
-      #     workspace-root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
-      #     create-repo: true
-      #     context: [CPE_ORBS_AWS]
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     extra-build-args: --compress
-      #     executor: amd64
-      #     role-arn: arn:aws:iam::122211685980:role/CPE_ECR_ADMIN
-      #     source-profile: default
-      #     new-profile-name: assume-role-test
-      #     lifecycle-policy-path: ./sample/policy.json
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile --force
-      #     platform: linux/amd64,linux/arm64
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      #     requires: [pre-integration]
+      - aws-ecr/build-and-push-image:
+          name: integration-tests-default-profile
+          attach-workspace: true
+          workspace-root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
+          create-repo: true
+          context: [CPE_ORBS_AWS]
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra-build-args: --compress
+          executor: amd64
+          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_ADMIN
+          source-profile: default
+          new-profile-name: assume-role-test
+          lifecycle-policy-path: ./sample/policy.json
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile --force
+          platform: linux/amd64,linux/arm64
+          filters:
+            tags:
+              only: /.*/
+          requires: [pre-integration]
 
       - aws-ecr/build-and-push-image:
           name: integration-tests-pubic-registry
@@ -71,6 +80,7 @@ workflows:
           create-repo: true
           role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           region: "us-west-2"
+          assume-web-identity: true
           profile-name: "OIDC-User"
           context: [CPE-OIDC] 
           tag: integration,myECRRepoTag
@@ -89,89 +99,101 @@ workflows:
               only: /.*/
           requires: [pre-integration]
 
-      # - aws-ecr/build-and-push-image:
-      #     name: integration-tests-named-profile
-      #     attach-workspace: true
-      #     context: [CPE_ORBS_AWS]
-      #     workspace-root: workspace
-      #     profile-name: testing
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-      #     create-repo: true
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     extra-build-args: --compress
-      #     region: ${AWS_REGION}
-      #     executor: amd64
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      #     requires: [pre-integration]
+      - aws-ecr/build-and-push-image:
+          name: integration-tests-named-profile
+          attach-workspace: true
+          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          region: "us-west-2"
+          assume-web-identity: true
+          profile-name: "OIDC-User"
+          context: [CPE-OIDC] 
+          workspace-root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+          create-repo: true
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra-build-args: --compress
+          executor: amd64
+          filters:
+            tags:
+              only: /.*/
+          requires: [pre-integration]
 
-      # - tag-ecr-image:
-      #     name: integration-tests-tag-existing-image
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-      #     context: [CPE_ORBS_AWS]
-      #     source-tag: integration
-      #     target-tag: latest
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile --force
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      #     requires:
-      #       - integration-tests-named-profile
+      - tag-ecr-image:
+          name: integration-tests-tag-existing-image
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          region: "us-west-2"
+          assume-web-identity: true
+          profile-name: "OIDC-User"
+          context: [CPE-OIDC] 
+          source-tag: integration
+          target-tag: latest
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile --force
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - integration-tests-named-profile
 
-      # - aws-ecr/build-and-push-image:
-      #     name: integration-tests-skip-when-tags-exist-populate-image-<<matrix.executor>>
-      #     attach-workspace: true
-      #     context: [CPE_ORBS_AWS]
-      #     workspace-root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
-      #     create-repo: true
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     extra-build-args: --compress
-      #     skip-when-tags-exist: true
-      #     region: ${AWS_REGION}
-      #     matrix:
-      #       parameters:
-      #         executor: ["amd64", "arm64"]
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      #     requires: [pre-integration]
+      - aws-ecr/build-and-push-image:
+          name: integration-tests-skip-when-tags-exist-populate-image-<<matrix.executor>>
+          attach-workspace: true
+          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          region: "us-west-2"
+          assume-web-identity: true
+          profile-name: "OIDC-User"
+          context: [CPE-OIDC]
+          workspace-root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
+          create-repo: true
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra-build-args: --compress
+          skip-when-tags-exist: true
+          matrix:
+            parameters:
+              executor: ["amd64", "arm64"]
+          filters:
+            tags:
+              only: /.*/
+          requires: [pre-integration]
 
-      # - aws-ecr/build-and-push-image:
-      #     name: integration-tests-skip-when-tags-exist-<<matrix.executor>>
-      #     attach-workspace: true
-      #     context: [CPE_ORBS_AWS]
-      #     workspace-root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     extra-build-args: --compress
-      #     skip-when-tags-exist: true
-      #     aws-cli-version: 2.4.10
-      #     region: ${AWS_REGION}
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: |
-      #             aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>> --force
-      #     matrix:
-      #       parameters:
-      #         executor: ["amd64", "arm64"]
-      #     filters:
-      #       tags:
-      #         only: /.*/
-      #     requires:
-      #       - integration-tests-skip-when-tags-exist-populate-image-amd64
-      #       - integration-tests-skip-when-tags-exist-populate-image-arm64
+      - aws-ecr/build-and-push-image:
+          name: integration-tests-skip-when-tags-exist-<<matrix.executor>>
+          attach-workspace: true
+          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          region: "us-west-2"
+          assume-web-identity: true
+          profile-name: "OIDC-User"
+          context: [CPE-OIDC]
+          workspace-root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra-build-args: --compress
+          skip-when-tags-exist: true
+          aws-cli-version: 2.4.10
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: |
+                  aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>> --force
+          matrix:
+            parameters:
+              executor: ["amd64", "arm64"]
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - integration-tests-skip-when-tags-exist-populate-image-amd64
+            - integration-tests-skip-when-tags-exist-populate-image-arm64
 
       - orb-tools/lint:
           filters:
@@ -193,12 +215,12 @@ workflows:
             - orb-tools/lint
             - orb-tools/review
             - orb-tools/pack
-            # - integration-tests-default-profile
+            - integration-tests-default-profile
             - integration-tests-pubic-registry
-            # - integration-tests-skip-when-tags-exist-amd64
-            # - integration-tests-skip-when-tags-exist-arm64
-            # - integration-tests-named-profile
-            # - integration-tests-tag-existing-image
+            - integration-tests-skip-when-tags-exist-amd64
+            - integration-tests-skip-when-tags-exist-arm64
+            - integration-tests-named-profile
+            - integration-tests-tag-existing-image
           github-token: GHI_TOKEN          
           context: orb-publisher
           filters:

--- a/sample/policy.json
+++ b/sample/policy.json
@@ -1,0 +1,17 @@
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Expire images older than 14 days",
+            "selection": {
+                "tagStatus": "untagged",
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": 14
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+ }

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,4 +8,4 @@ display:
   home_url: https://aws.amazon.com/ecr/
 
 orbs:
-  aws-cli: circleci/aws-cli@dev:alpha
+  aws-cli: circleci/aws-cli@3.1

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,4 +8,4 @@ display:
   home_url: https://aws.amazon.com/ecr/
 
 orbs:
-  aws-cli: circleci/aws-cli@2.1.0
+  aws-cli: circleci/aws-cli@dev:alpha

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -36,6 +36,16 @@ parameters:
     default: ""
     description: Role ARN that the profile should take.
 
+  role-session-name:
+    description: An identifier for the assumed role session
+    type: string
+    default: ${CIRCLE_JOB}
+
+  session-duration:
+    description: The duration of the session in seconds
+    type: string
+    default: '3600'
+
   source-profile:
     description: Source profile containing credentials to assume the role with role-arn.
     type: string
@@ -225,6 +235,8 @@ steps:
       aws-cli-version: <<parameters.aws-cli-version>>
       public-registry: <<parameters.public-registry>>
       role-arn: <<parameters.role-arn>>
+      role-session-name: <<parameters.role-session-name>>
+      session-duration: <<parameters.session-duration>>
       new-profile-name: <<parameters.new-profile-name>>
       source-profile: <<parameters.source-profile>>
 

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -256,9 +256,9 @@ steps:
   - when:
       condition:
         and:
-          - not: <<parameters.role-arn>>
-          - not: <<parameters.new-profile-name>>
+          - <<parameters.role-arn>>
           - <<parameters.create-repo>>
+          - <<parameters.role-session-name>>
       steps:
         - create-repo:
             profile-name: <<parameters.profile-name>>

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -247,19 +247,6 @@ steps:
       source-profile: <<parameters.source-profile>>
 
   - when:
-      condition:
-        and:
-          - <<parameters.create-repo>>
-          - <<parameters.role-arn>>
-          - <<parameters.new-profile-name>>
-      steps:
-        - create-repo:
-            profile-name: <<parameters.profile-name>>
-            region: <<parameters.region>>
-            repo: <<parameters.repo>>
-            repo-scan-on-push: <<parameters.repo-scan-on-push>>
-            public-registry: <<parameters.public-registry>>
-  - when:
       condition: <<parameters.create-repo>>
       steps:
         - create-repo:
@@ -268,6 +255,31 @@ steps:
             repo: <<parameters.repo>>
             repo-scan-on-push: <<parameters.repo-scan-on-push>>
             public-registry: <<parameters.public-registry>>
+  # - when:
+  #     condition:
+  #       and:
+  #         - <<parameters.create-repo>>
+  #         - <<parameters.role-arn>>
+  #         - <<parameters.new-profile-name>>
+  #     steps:
+  #       - create-repo:
+  #           profile-name: <<parameters.profile-name>>
+  #           region: <<parameters.region>>
+  #           repo: <<parameters.repo>>
+  #           repo-scan-on-push: <<parameters.repo-scan-on-push>>
+  #           public-registry: <<parameters.public-registry>>
+  # - when:
+  #     condition: 
+  #       and: 
+  #         - <<parameters.create-repo>>
+  #         - not: <<parameters.new-profile-name>>
+  #     steps:
+  #       - create-repo:
+  #           profile-name: <<parameters.profile-name>>
+  #           region: <<parameters.region>>
+  #           repo: <<parameters.repo>>
+  #           repo-scan-on-push: <<parameters.repo-scan-on-push>>
+  #           public-registry: <<parameters.public-registry>>
   - when:
       condition: <<parameters.docker-login>>
       steps:

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -269,8 +269,8 @@ steps:
   #           repo-scan-on-push: <<parameters.repo-scan-on-push>>
   #           public-registry: <<parameters.public-registry>>
   # - when:
-  #     condition: 
-  #       and: 
+  #     condition:
+  #       and:
   #         - <<parameters.create-repo>>
   #         - not: <<parameters.new-profile-name>>
   #     steps:

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -46,6 +46,11 @@ parameters:
     type: string
     default: '3600'
 
+  assume-web-identity:
+    description: Set to true to configure a profile using short-term credentials
+    type: boolean
+    default: false
+
   source-profile:
     description: Source profile containing credentials to assume the role with role-arn.
     type: string
@@ -235,6 +240,7 @@ steps:
       aws-cli-version: <<parameters.aws-cli-version>>
       public-registry: <<parameters.public-registry>>
       role-arn: <<parameters.role-arn>>
+      assume-web-identity: <<parameters.assume-web-identity>>
       role-session-name: <<parameters.role-session-name>>
       session-duration: <<parameters.session-duration>>
       new-profile-name: <<parameters.new-profile-name>>
@@ -254,11 +260,7 @@ steps:
             repo-scan-on-push: <<parameters.repo-scan-on-push>>
             public-registry: <<parameters.public-registry>>
   - when:
-      condition:
-        and:
-          - <<parameters.role-arn>>
-          - <<parameters.create-repo>>
-          - <<parameters.role-session-name>>
+      condition: <<parameters.create-repo>>
       steps:
         - create-repo:
             profile-name: <<parameters.profile-name>>

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -44,7 +44,7 @@ parameters:
   session-duration:
     description: The duration of the session in seconds
     type: string
-    default: '3600'
+    default: "3600"
 
   assume-web-identity:
     description: Set to true to configure a profile using short-term credentials
@@ -255,31 +255,7 @@ steps:
             repo: <<parameters.repo>>
             repo-scan-on-push: <<parameters.repo-scan-on-push>>
             public-registry: <<parameters.public-registry>>
-  # - when:
-  #     condition:
-  #       and:
-  #         - <<parameters.create-repo>>
-  #         - <<parameters.role-arn>>
-  #         - <<parameters.new-profile-name>>
-  #     steps:
-  #       - create-repo:
-  #           profile-name: <<parameters.profile-name>>
-  #           region: <<parameters.region>>
-  #           repo: <<parameters.repo>>
-  #           repo-scan-on-push: <<parameters.repo-scan-on-push>>
-  #           public-registry: <<parameters.public-registry>>
-  # - when:
-  #     condition:
-  #       and:
-  #         - <<parameters.create-repo>>
-  #         - not: <<parameters.new-profile-name>>
-  #     steps:
-  #       - create-repo:
-  #           profile-name: <<parameters.profile-name>>
-  #           region: <<parameters.region>>
-  #           repo: <<parameters.repo>>
-  #           repo-scan-on-push: <<parameters.repo-scan-on-push>>
-  #           public-registry: <<parameters.public-registry>>
+
   - when:
       condition: <<parameters.docker-login>>
       steps:

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -1,0 +1,304 @@
+description: >
+  Install AWS CLI, if needed, and configure. Log into Amazon ECR and push image
+  to repository. Requires environment variables for AWS_ACCESS_KEY_ID and
+  AWS_SECRET_ACCESS_KEY. We recommend these be saved in a Project
+  (https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project)
+  or in Contexts (https://circleci.com/docs/2.0/contexts).
+parameters:
+  registry-id:
+    type: env_var_name
+    default: AWS_ECR_REGISTRY_ID
+    description: >
+      The 12 digit AWS id associated with the ECR account.
+      This field is required
+
+  profile-name:
+    default: default
+    description: AWS profile name to be configured.
+    type: string
+
+  aws-access-key-id:
+    default: AWS_ACCESS_KEY_ID
+    description: >
+      AWS access key id for IAM role. Set this to the name of the environment
+      variable you will set to hold this value, i.e. AWS_ACCESS_KEY.
+    type: env_var_name
+
+  aws-secret-access-key:
+    default: AWS_SECRET_ACCESS_KEY
+    description: >
+      AWS secret key for IAM role. Set this to the name of the environment
+      variable you will set to hold this value, i.e. AWS_SECRET_ACCESS_KEY.
+    type: env_var_name
+
+  role-arn:
+    type: string
+    default: ""
+    description: Role ARN that the profile should take.
+
+  source-profile:
+    description: Source profile containing credentials to assume the role with role-arn.
+    type: string
+    default: "default"
+
+  new-profile-name:
+    description: Name of new profile associated with role arn.
+    type: string
+    default: ""
+
+  aws-cli-version:
+    description: Select a specific version of the AWS v2 CLI. By default the latest version will be used.
+    default: latest
+    type: string
+
+  region:
+    default: ${AWS_REGION}
+    description: >
+      Name of env var storing your AWS region information, defaults to
+      AWS_REGION
+    type: string
+
+  public-registry:
+    type: boolean
+    description: >
+      Set to true if building and pushing an image to a Public Registry on ECR.
+    default: false
+
+  repo:
+    description: Name of an Amazon ECR repository
+    type: string
+
+  create-repo:
+    default: false
+    description: Should the repo be created if it does not exist?
+    type: boolean
+
+  repo-scan-on-push:
+    default: true
+    description: Should the created repo be security scanned on push?
+    type: boolean
+
+  tag:
+    default: latest
+    description: >
+      A comma-separated string containing docker image tags to build and push
+      (default = latest)
+    type: string
+
+  attach-workspace:
+    default: false
+    description: >
+      Boolean for whether or not to attach to an existing workspace. Default is
+      false.
+    type: boolean
+
+  workspace-root:
+    default: .
+    description: >
+      Workspace root path that is either an absolute path or a path relative to
+      the working directory. Defaults to '.' (the working directory)
+    type: string
+
+  setup-remote-docker:
+    default: false
+    description: >
+      Setup and use CircleCI's remote Docker environment for Docker and
+      docker-compose commands? Not required if using the default executor
+    type: boolean
+
+  remote-docker-version:
+    default: 19.03.13
+    description: Specific remote docker version
+    type: string
+
+  remote-docker-layer-caching:
+    default: false
+    description: >
+      Enable Docker layer caching if using remote Docker engine. Defaults to
+      false.
+    type: boolean
+
+  docker-login:
+    default: false
+    description: |
+      Enable dockerhub authentication. Defaults to false.
+    type: boolean
+
+  dockerhub-username:
+    default: DOCKERHUB_USERNAME
+    description: >
+      Dockerhub username to be configured. Set this to the name of the
+      environment variable you will set to hold this value, i.e.
+      DOCKERHUB_USERNAME.
+    type: env_var_name
+
+  dockerhub-password:
+    default: DOCKERHUB_PASSWORD
+    description: >
+      Dockerhub password to be configured. Set this to the name of the
+      environment variable you will set to hold this value, i.e.
+      DOCKERHUB_PASSWORD.
+    type: env_var_name
+
+  dockerfile:
+    default: Dockerfile
+    description: Name of dockerfile to use. Defaults to Dockerfile.
+    type: string
+
+  path:
+    default: .
+    description: >-
+      Path to the directory containing your Dockerfile and build context.
+      Defaults to . (working directory).
+    type: string
+
+  extra-build-args:
+    default: ""
+    description: >
+      Extra flags to pass to docker build. For examples, see
+      https://docs.docker.com/engine/reference/commandline/build
+    type: string
+
+  no-output-timeout:
+    default: 10m
+    description: >
+      The amount of time to allow the docker build command to run before timing
+      out (default is `10m`)
+    type: string
+
+  skip-when-tags-exist:
+    default: false
+    description: Whether to skip image building if all specified tags already exist in ECR
+    type: boolean
+
+  platform:
+    type: string
+    default: "linux/amd64"
+    description: Platform targets for the docker image, multi arch images. Ex. linux/amd64,linux/arm64
+
+  push-image:
+    type: boolean
+    default: true
+    description: Set to false to build an image without pushing to repository.  Defaults to true.
+
+  lifecycle-policy-path:
+    type: string
+    default: ""
+    description: |
+      The path to the .json file containing the lifecycle policy to be applied to a specified repository in AWS ECR.
+
+  checkout:
+    default: true
+    description: |
+      Boolean for whether or not to checkout as a first step. Default is true.
+    type: boolean
+
+steps:
+  - when:
+      condition: <<parameters.checkout>>
+      steps:
+        - checkout
+  - when:
+      condition: <<parameters.attach-workspace>>
+      steps:
+        - attach_workspace:
+            at: <<parameters.workspace-root>>
+  - when:
+      condition:
+        and:
+          - <<parameters.setup-remote-docker>>
+          - not: <<parameters.setup-remote-docker>>
+      steps:
+        - run: echo "Docker Layer Caching requires Setup Remote Docker command" && exit 1
+  - when:
+      condition: <<parameters.setup-remote-docker>>
+      steps:
+        - setup_remote_docker:
+            docker_layer_caching: <<parameters.remote-docker-layer-caching>>
+            version: <<parameters.remote-docker-version>>
+  - ecr-login:
+      profile-name: <<parameters.profile-name>>
+      region: <<parameters.region>>
+      registry-id: <<parameters.registry-id>>
+      aws-access-key-id: <<parameters.aws-access-key-id>>
+      aws-secret-access-key: <<parameters.aws-secret-access-key>>
+      aws-cli-version: <<parameters.aws-cli-version>>
+      public-registry: <<parameters.public-registry>>
+      role-arn: <<parameters.role-arn>>
+      new-profile-name: <<parameters.new-profile-name>>
+      source-profile: <<parameters.source-profile>>
+
+  - when:
+      condition:
+        and:
+          - <<parameters.create-repo>>
+          - <<parameters.role-arn>>
+          - <<parameters.new-profile-name>>
+      steps:
+        - create-repo:
+            profile-name: <<parameters.profile-name>>
+            region: <<parameters.region>>
+            repo: <<parameters.repo>>
+            repo-scan-on-push: <<parameters.repo-scan-on-push>>
+            public-registry: <<parameters.public-registry>>
+  - when:
+      condition:
+        and:
+          - not: <<parameters.role-arn>>
+          - not: <<parameters.new-profile-name>>
+          - <<parameters.create-repo>>
+      steps:
+        - create-repo:
+            profile-name: <<parameters.profile-name>>
+            region: <<parameters.region>>
+            repo: <<parameters.repo>>
+            repo-scan-on-push: <<parameters.repo-scan-on-push>>
+            public-registry: <<parameters.public-registry>>
+  - when:
+      condition: <<parameters.docker-login>>
+      steps:
+        - run: >
+            docker login -u $<<parameters.dockerhub-username>> -p
+            $<<parameters.dockerhub-password>>
+  - when:
+      condition:
+        and:
+          - <<parameters.role-arn>>
+          - <<parameters.new-profile-name>>
+      steps:
+        - build-image:
+            registry-id: <<parameters.registry-id>>
+            repo: <<parameters.repo>>
+            tag: <<parameters.tag>>
+            dockerfile: <<parameters.dockerfile>>
+            path: <<parameters.path>>
+            extra-build-args: <<parameters.extra-build-args>>
+            no-output-timeout: <<parameters.no-output-timeout>>
+            skip-when-tags-exist: <<parameters.skip-when-tags-exist>>
+            profile-name: <<parameters.new-profile-name>>
+            platform: <<parameters.platform>>
+            region: <<parameters.region>>
+            public-registry: <<parameters.public-registry>>
+            push-image: <<parameters.push-image>>
+
+  - unless:
+      condition:
+        and:
+          - <<parameters.role-arn>>
+          - <<parameters.new-profile-name>>
+      steps:
+        - build-image:
+            registry-id: <<parameters.registry-id>>
+            repo: <<parameters.repo>>
+            tag: <<parameters.tag>>
+            dockerfile: <<parameters.dockerfile>>
+            path: <<parameters.path>>
+            extra-build-args: <<parameters.extra-build-args>>
+            no-output-timeout: <<parameters.no-output-timeout>>
+            skip-when-tags-exist: <<parameters.skip-when-tags-exist>>
+            profile-name: <<parameters.profile-name>>
+            platform: <<parameters.platform>>
+            region: <<parameters.region>>
+            public-registry: <<parameters.public-registry>>
+            push-image: <<parameters.push-image>>
+            lifecycle-policy-path: <<parameters.lifecycle-policy-path>>

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -71,6 +71,13 @@ parameters:
     type: boolean
     default: true
     description: Set to false to build an image without pushing to repository.  Defaults to true.
+  
+  lifecycle-policy-path:
+    type: string
+    default: ""
+    description: | 
+      The path to the .json file containing the lifecycle policy to be applied to a specified repository in AWS ECR.
+
 
 steps:
   - run:
@@ -88,5 +95,6 @@ steps:
         PARAM_PLATFORM: <<parameters.platform>>
         PARAM_PUBLIC_REGISTRY: <<parameters.public-registry>>
         PARAM_PUSH_IMAGE: <<parameters.push-image>>
+        PARAM_LIFECYCLE_POLICY_PATH: <<parameters.lifecycle-policy-path>>
       command: <<include(scripts/docker-buildx.sh)>>
       no_output_timeout: <<parameters.no-output-timeout>>

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -78,7 +78,6 @@ parameters:
     description: |
       The path to the .json file containing the lifecycle policy to be applied to a specified repository in AWS ECR.
 
-
 steps:
   - run:
       name: Build Docker Image with buildx

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -71,11 +71,11 @@ parameters:
     type: boolean
     default: true
     description: Set to false to build an image without pushing to repository.  Defaults to true.
-  
+
   lifecycle-policy-path:
     type: string
     default: ""
-    description: | 
+    description: |
       The path to the .json file containing the lifecycle policy to be applied to a specified repository in AWS ECR.
 
 

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -35,6 +35,11 @@ parameters:
     type: string
     default: '3600'
 
+  assume-web-identity:
+    description: Set to true to configure a profile using short-term credentials
+    type: boolean
+    default: false
+
   source-profile:
     description: Source profile containing credentials to assume the role with role-arn.
     type: string
@@ -73,10 +78,7 @@ parameters:
 
 steps:
   - when:
-      condition:
-        and:
-          - <<parameters.role-arn>>
-          - <<parameters.role-session-name>>
+      condition: <<parameters.assume-web-identity>>
       steps:
         - aws-cli/setup:
             profile-name: <<parameters.profile-name>>
@@ -86,9 +88,7 @@ steps:
             session-duration: <<parameters.session-duration>>
   - when:
       condition:
-        and:
-          - not: <<parameters.role-arn>>
-          - not: <<parameters.role-session-name>>
+          not: <<parameters.assume-web-identity>>
       steps:
         - aws-cli/setup:
             profile-name: <<parameters.profile-name>>

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -33,7 +33,7 @@ parameters:
   session-duration:
     description: The duration of the session in seconds
     type: string
-    default: '3600'
+    default: "3600"
 
   assume-web-identity:
     description: Set to true to configure a profile using short-term credentials
@@ -88,7 +88,7 @@ steps:
             session-duration: <<parameters.session-duration>>
   - when:
       condition:
-          not: <<parameters.assume-web-identity>>
+        not: <<parameters.assume-web-identity>>
       steps:
         - aws-cli/setup:
             profile-name: <<parameters.profile-name>>

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -75,12 +75,31 @@ steps:
             profile-name: <<parameters.new-profile-name>>
             role-arn: <<parameters.role-arn>>
             source-profile: <<parameters.source-profile>>
-
-  - run:
-      name: Log into Amazon ECR
-      environment:
-        PARAM_PROFILE_NAME: <<parameters.profile-name>>
-        PARAM_REGISTRY_ID: <<parameters.registry-id>>
-        PARAM_REGION: <<parameters.region>>
-        PARAM_PUBLIC_REGISTRY: <<parameters.public-registry>>
-      command: <<include(scripts/ecr-login.sh)>>
+  - when:
+      condition:
+        and:
+          - <<parameters.role-arn>>
+          - <<parameters.new-profile-name>>
+      steps:
+        - run:
+            name: Log into Amazon ECR with profile <<parameters.new-profile-name>>
+            environment:
+              PARAM_PROFILE_NAME: <<parameters.new-profile-name>>
+              PARAM_REGISTRY_ID: <<parameters.registry-id>>
+              PARAM_REGION: <<parameters.region>>
+              PARAM_PUBLIC_REGISTRY: <<parameters.public-registry>>
+            command: <<include(scripts/ecr-login.sh)>>
+  - unless:
+      condition:
+        and:
+          - <<parameters.role-arn>>
+          - <<parameters.new-profile-name>>
+      steps:
+        - run:
+            name: Log into Amazon ECR with profile <<parameters.profile-name>>
+            environment:
+              PARAM_PROFILE_NAME: <<parameters.profile-name>>
+              PARAM_REGISTRY_ID: <<parameters.registry-id>>
+              PARAM_REGION: <<parameters.region>>
+              PARAM_PUBLIC_REGISTRY: <<parameters.public-registry>>
+            command: <<include(scripts/ecr-login.sh)>>

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -16,7 +16,7 @@ parameters:
 
   profile-name:
     type: string
-    default: ""
+    default: "default"
     description: >
       AWS profile name to be configured.
 
@@ -24,6 +24,16 @@ parameters:
     type: string
     default: ""
     description: Role ARN that the profile should take.
+
+  role-session-name:
+    description: An identifier for the assumed role session
+    type: string
+    default: ${CIRCLE_JOB}
+
+  session-duration:
+    description: The duration of the session in seconds
+    type: string
+    default: '3600'
 
   source-profile:
     description: Source profile containing credentials to assume the role with role-arn.
@@ -62,14 +72,36 @@ parameters:
     default: false
 
 steps:
-  - aws-cli/setup:
-      profile-name: <<parameters.profile-name>>
-      aws-access-key-id: <<parameters.aws-access-key-id>>
-      aws-secret-access-key: <<parameters.aws-secret-access-key>>
-      version: <<parameters.aws-cli-version>>
+  - when:
+      condition:
+        and:
+          - <<parameters.role-arn>>
+          - <<parameters.role-session-name>>
+      steps:
+        - aws-cli/setup:
+            profile-name: <<parameters.profile-name>>
+            version: <<parameters.aws-cli-version>>
+            role-arn: <<parameters.role-arn>>
+            role-session-name: <<parameters.role-session-name>>
+            session-duration: <<parameters.session-duration>>
+  - when:
+      condition:
+        and:
+          - not: <<parameters.role-arn>>
+          - not: <<parameters.role-session-name>>
+      steps:
+        - aws-cli/setup:
+            profile-name: <<parameters.profile-name>>
+            aws-access-key-id: <<parameters.aws-access-key-id>>
+            aws-secret-access-key: <<parameters.aws-secret-access-key>>
+            version: <<parameters.aws-cli-version>>
 
   - when:
-      condition: <<parameters.role-arn>>
+      condition:
+        and:
+          - <<parameters.role-arn>>
+          - <<parameters.source-profile>>
+          - <<parameters.new-profile-name>>
       steps:
         - aws-cli/role-arn-setup:
             profile-name: <<parameters.new-profile-name>>

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -218,7 +218,24 @@ steps:
       source-profile: <<parameters.source-profile>>
 
   - when:
-      condition: <<parameters.create-repo>>
+      condition:
+        and:
+          - <<parameters.create-repo>>
+          - <<parameters.role-arn>>
+          - <<parameters.new-profile-name>>
+      steps:
+        - create-repo:
+            profile-name: <<parameters.new-profile-name>>
+            region: <<parameters.region>>
+            repo: <<parameters.repo>>
+            repo-scan-on-push: <<parameters.repo-scan-on-push>>
+            public-registry: <<parameters.public-registry>>
+  - when:
+      condition:
+        and:
+          - not: <<parameters.role-arn>>
+          - not: <<parameters.new-profile-name>>
+          - <<parameters.create-repo>>
       steps:
         - create-repo:
             profile-name: <<parameters.profile-name>>
@@ -233,19 +250,43 @@ steps:
         - run: |
             docker login -u $<<parameters.dockerhub-username>> -p $<<parameters.dockerhub-password>>
 
-  - build-image:
-      registry-id: <<parameters.registry-id>>
-      repo: <<parameters.repo>>
-      tag: <<parameters.tag>>
-      dockerfile: <<parameters.dockerfile>>
-      path: <<parameters.path>>
-      extra-build-args: <<parameters.extra-build-args>>
-      no-output-timeout: <<parameters.no-output-timeout>>
-      skip-when-tags-exist: <<parameters.skip-when-tags-exist>>
-      profile-name: <<parameters.profile-name>>
-      platform: <<parameters.platform>>
-      region: <<parameters.region>>
-      public-registry: <<parameters.public-registry>>
-      push-image: <<parameters.push-image>>
-  - store_artifacts:
-      path: test.txt
+  - when:
+      condition:
+        and:
+          - <<parameters.role-arn>>
+          - <<parameters.new-profile-name>>
+      steps:
+        - build-image:
+            registry-id: <<parameters.registry-id>>
+            repo: <<parameters.repo>>
+            tag: <<parameters.tag>>
+            dockerfile: <<parameters.dockerfile>>
+            path: <<parameters.path>>
+            extra-build-args: <<parameters.extra-build-args>>
+            no-output-timeout: <<parameters.no-output-timeout>>
+            skip-when-tags-exist: <<parameters.skip-when-tags-exist>>
+            profile-name: <<parameters.new-profile-name>>
+            platform: <<parameters.platform>>
+            region: <<parameters.region>>
+            public-registry: <<parameters.public-registry>>
+            push-image: <<parameters.push-image>>
+  - unless:
+      condition:
+        and:
+          - <<parameters.role-arn>>
+          - <<parameters.new-profile-name>>
+      steps:
+        - build-image:
+            registry-id: <<parameters.registry-id>>
+            repo: <<parameters.repo>>
+            tag: <<parameters.tag>>
+            dockerfile: <<parameters.dockerfile>>
+            path: <<parameters.path>>
+            extra-build-args: <<parameters.extra-build-args>>
+            no-output-timeout: <<parameters.no-output-timeout>>
+            skip-when-tags-exist: <<parameters.skip-when-tags-exist>>
+            profile-name: <<parameters.profile-name>>
+            platform: <<parameters.platform>>
+            region: <<parameters.region>>
+            public-registry: <<parameters.public-registry>>
+            push-image: <<parameters.push-image>>

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -60,7 +60,7 @@ parameters:
   session-duration:
     description: The duration of the session in seconds
     type: string
-    default: '3600'
+    default: "3600"
 
   source-profile:
     description: Source profile containing credentials to assume the role with role-arn.

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -47,6 +47,16 @@ parameters:
     default: ""
     description: Role ARN that the profile should take.
 
+  role-session-name:
+    description: An identifier for the assumed role session
+    type: string
+    default: ${CIRCLE_JOB}
+
+  session-duration:
+    description: The duration of the session in seconds
+    type: string
+    default: '3600'
+
   source-profile:
     description: Source profile containing credentials to assume the role with role-arn.
     type: string
@@ -212,6 +222,8 @@ steps:
       aws-secret-access-key: <<parameters.aws-secret-access-key>>
       aws-cli-version: <<parameters.aws-cli-version>>
       role-arn: <<parameters.role-arn>>
+      role-session-name: <<parameters.role-session-name>>
+      session-duration: <<parameters.session-duration>>
       new-profile-name: <<parameters.new-profile-name>>
       source-profile: <<parameters.source-profile>>
       attach-workspace: <<parameters.attach-workspace>>

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -52,6 +52,11 @@ parameters:
     type: string
     default: ${CIRCLE_JOB}
 
+  assume-web-identity:
+    description: Set to true to configure a profile using short-term credentials
+    type: boolean
+    default: false
+
   session-duration:
     description: The duration of the session in seconds
     type: string
@@ -223,6 +228,7 @@ steps:
       aws-cli-version: <<parameters.aws-cli-version>>
       role-arn: <<parameters.role-arn>>
       role-session-name: <<parameters.role-session-name>>
+      assume-web-identity: <<parameters.assume-web-identity>>
       session-duration: <<parameters.session-duration>>
       new-profile-name: <<parameters.new-profile-name>>
       source-profile: <<parameters.source-profile>>

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -192,108 +192,34 @@ parameters:
       The path to the .json file containing the lifecycle policy to be applied to a specified repository in AWS ECR.
 
 steps:
-  - checkout
-  - when:
-      condition: <<parameters.attach-workspace>>
-      steps:
-        - attach_workspace:
-            at: <<parameters.workspace-root>>
-  - when:
-      condition:
-        and:
-          - <<parameters.remote-docker-layer-caching>>
-          - not: <<parameters.setup-remote-docker>>
-      steps:
-        - run: echo "Docker Layer Caching requires Setup Remote Docker command" && exit 1
-  - when:
-      condition: <<parameters.setup-remote-docker>>
-      steps:
-        - setup_remote_docker:
-            version: <<parameters.remote-docker-version>>
-            docker_layer_caching: <<parameters.remote-docker-layer-caching>>
-  - ecr-login:
-      profile-name: <<parameters.profile-name>>
-      region: <<parameters.region>>
+  - build-and-push-image:
       registry-id: <<parameters.registry-id>>
+      repo: <<parameters.repo>>
+      tag: <<parameters.tag>>
+      dockerfile: <<parameters.dockerfile>>
+      path: <<parameters.path>>
+      extra-build-args: <<parameters.extra-build-args>>
+      no-output-timeout: <<parameters.no-output-timeout>>
+      skip-when-tags-exist: <<parameters.skip-when-tags-exist>>
+      profile-name: <<parameters.profile-name>>
+      platform: <<parameters.platform>>
+      region: <<parameters.region>>
+      public-registry: <<parameters.public-registry>>
+      push-image: <<parameters.push-image>>
+      lifecycle-policy-path: <<parameters.lifecycle-policy-path>>
+      repo-scan-on-push: <<parameters.repo-scan-on-push>>
       aws-access-key-id: <<parameters.aws-access-key-id>>
       aws-secret-access-key: <<parameters.aws-secret-access-key>>
       aws-cli-version: <<parameters.aws-cli-version>>
-      public-registry: <<parameters.public-registry>>
       role-arn: <<parameters.role-arn>>
       new-profile-name: <<parameters.new-profile-name>>
       source-profile: <<parameters.source-profile>>
-
-  - when:
-      condition:
-        and:
-          - <<parameters.create-repo>>
-          - <<parameters.role-arn>>
-          - <<parameters.new-profile-name>>
-      steps:
-        - create-repo:
-            profile-name: <<parameters.new-profile-name>>
-            region: <<parameters.region>>
-            repo: <<parameters.repo>>
-            repo-scan-on-push: <<parameters.repo-scan-on-push>>
-            public-registry: <<parameters.public-registry>>
-  - when:
-      condition:
-        and:
-          - not: <<parameters.role-arn>>
-          - not: <<parameters.new-profile-name>>
-          - <<parameters.create-repo>>
-      steps:
-        - create-repo:
-            profile-name: <<parameters.profile-name>>
-            region: <<parameters.region>>
-            repo: <<parameters.repo>>
-            repo-scan-on-push: <<parameters.repo-scan-on-push>>
-            public-registry: <<parameters.public-registry>>
-
-  - when:
-      condition: <<parameters.docker-login>>
-      steps:
-        - run: |
-            docker login -u $<<parameters.dockerhub-username>> -p $<<parameters.dockerhub-password>>
-
-  - when:
-      condition:
-        and:
-          - <<parameters.role-arn>>
-          - <<parameters.new-profile-name>>
-      steps:
-        - build-image:
-            registry-id: <<parameters.registry-id>>
-            repo: <<parameters.repo>>
-            tag: <<parameters.tag>>
-            dockerfile: <<parameters.dockerfile>>
-            path: <<parameters.path>>
-            extra-build-args: <<parameters.extra-build-args>>
-            no-output-timeout: <<parameters.no-output-timeout>>
-            skip-when-tags-exist: <<parameters.skip-when-tags-exist>>
-            profile-name: <<parameters.new-profile-name>>
-            platform: <<parameters.platform>>
-            region: <<parameters.region>>
-            public-registry: <<parameters.public-registry>>
-            push-image: <<parameters.push-image>>
-  - unless:
-      condition:
-        and:
-          - <<parameters.role-arn>>
-          - <<parameters.new-profile-name>>
-      steps:
-        - build-image:
-            registry-id: <<parameters.registry-id>>
-            repo: <<parameters.repo>>
-            tag: <<parameters.tag>>
-            dockerfile: <<parameters.dockerfile>>
-            path: <<parameters.path>>
-            extra-build-args: <<parameters.extra-build-args>>
-            no-output-timeout: <<parameters.no-output-timeout>>
-            skip-when-tags-exist: <<parameters.skip-when-tags-exist>>
-            profile-name: <<parameters.profile-name>>
-            platform: <<parameters.platform>>
-            region: <<parameters.region>>
-            public-registry: <<parameters.public-registry>>
-            push-image: <<parameters.push-image>>
-            lifecycle-policy-path: <<parameters.lifecycle-policy-path>>
+      attach-workspace: <<parameters.attach-workspace>>
+      remote-docker-layer-caching: <<parameters.remote-docker-layer-caching>>
+      setup-remote-docker: <<parameters.setup-remote-docker>>
+      remote-docker-version: <<parameters.remote-docker-version>>
+      workspace-root: <<parameters.workspace-root>>
+      create-repo: <<parameters.create-repo>>
+      docker-login: <<parameters.docker-login>>
+      dockerhub-username: <<parameters.dockerhub-username>>
+      dockerhub-password: <<parameters.dockerhub-password>>

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -185,6 +185,12 @@ parameters:
     default: true
     description: Set to false to build an image without pushing to repository.  Defaults to true.
 
+  lifecycle-policy-path:
+    type: string
+    default: ""
+    description: |
+      The path to the .json file containing the lifecycle policy to be applied to a specified repository in AWS ECR.
+
 steps:
   - checkout
   - when:
@@ -290,3 +296,4 @@ steps:
             region: <<parameters.region>>
             public-registry: <<parameters.public-registry>>
             push-image: <<parameters.push-image>>
+            lifecycle-policy-path: <<parameters.lifecycle-policy-path>>

--- a/src/scripts/create-repo.sh
+++ b/src/scripts/create-repo.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
-REGION=$(eval echo "${PARAM_REGION}")
-REPO=$(eval echo "${PARAM_REPO}")
 
 if [ "$PARAM_PUBLIC_REGISTRY" == "1" ]; then
-    aws ecr-public describe-repositories --profile "${PARAM_PROFILE_NAME}" --region us-east-1 --repository-names "${REPO}" >/dev/null 2>&1 ||
-        aws ecr-public create-repository --profile "${PARAM_PROFILE_NAME}" --region us-east-1 --repository-name "${REPO}"
+    aws ecr-public describe-repositories --profile "${PARAM_PROFILE_NAME}" --region us-east-1 --repository-names "${PARAM_REPO}" >/dev/null 2>&1 ||
+        aws ecr-public create-repository --profile "${PARAM_PROFILE_NAME}" --region us-east-1 --repository-name "${PARAM_REPO}"
 else
-    aws ecr describe-repositories --profile "${PARAM_PROFILE_NAME}" --region "${REGION}" --repository-names "${REPO}" >/dev/null 2>&1 ||
+    aws ecr describe-repositories --profile "${PARAM_PROFILE_NAME}" --region "${PARAM_REGION}" --repository-names "${PARAM_REPO}" >/dev/null 2>&1 ||
         if [ "$PARAM_REPO_SCAN_ON_PUSH" == "1" ]; then
-            aws ecr create-repository --profile "${PARAM_PROFILE_NAME}" --region "${REGION}" --repository-name "${REPO}" --image-scanning-configuration scanOnPush=true
+            aws ecr create-repository --profile "${PARAM_PROFILE_NAME}" --region "${PARAM_REGION}" --repository-name "${PARAM_REPO}" --image-scanning-configuration scanOnPush=true
         else
-            aws ecr create-repository --profile "${PARAM_PROFILE_NAME}" --region "${REGION}" --repository-name "${REPO}" --image-scanning-configuration scanOnPush=false
+            aws ecr create-repository --profile "${PARAM_PROFILE_NAME}" --region "${PARAM_REGION}" --repository-name "${PARAM_REPO}" --image-scanning-configuration scanOnPush=false
         fi
 fi

--- a/src/scripts/create-repo.sh
+++ b/src/scripts/create-repo.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+PARAM_REGION=$(eval echo "${PARAM_REGION}")
+PARAM_REPO=$(eval echo "${PARAM_REPO}")
 
 if [ "$PARAM_PUBLIC_REGISTRY" == "1" ]; then
     aws ecr-public describe-repositories --profile "${PARAM_PROFILE_NAME}" --region us-east-1 --repository-names "${PARAM_REPO}" >/dev/null 2>&1 ||

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
+PARAM_REGION=$(eval echo "${PARAM_REGION}")
+PARAM_REPO=$(eval echo "${PARAM_REPO}")
+PARAM_TAG=$(eval echo "${PARAM_TAG}")
 PARAM_ACCOUNT_URL="${!PARAM_REGISTRY_ID}.dkr.ecr.${PARAM_REGION}.amazonaws.com"
 ECR_COMMAND="ecr"
 number_of_tags_in_ecr=0
 docker_tag_args=""
+
 
 IFS="," read -ra PLATFORMS <<<"${PARAM_PLATFORM}"
 arch_count=${#PLATFORMS[@]}
@@ -20,9 +24,9 @@ fi
 IFS="," read -ra DOCKER_TAGS <<<"${PARAM_TAG}"
 for tag in "${DOCKER_TAGS[@]}"; do
   if [ "${PARAM_SKIP_WHEN_TAGS_EXIST}" = "1" ]; then
-    docker_tag_exists_in_ecr=$(aws "${ECR_COMMAND}" describe-images --profile "${PARAM_PROFILE_NAME}" --registry-id "${!PARAM_REGISTRY_ID}" --region "${REGION}" --repository-name "${PARAM_REPO}" --query "contains(imageDetails[].imageTags[], '${tag}')")
+    docker_tag_exists_in_ecr=$(aws "${ECR_COMMAND}" describe-images --profile "${PARAM_PROFILE_NAME}" --registry-id "${!PARAM_REGISTRY_ID}" --region "${PARAM_REGION}" --repository-name "${PARAM_REPO}" --query "contains(imageDetails[].imageTags[], '${tag}')")
     if [ "${docker_tag_exists_in_ecr}" = "1" ]; then
-      docker pull "${PARAM_ACCOUNT_URL}/${PARAM_REP}:${tag}"
+      docker pull "${PARAM_ACCOUNT_URL}/${PARAM_REPO}:${tag}"
       number_of_tags_in_ecr=$((number_of_tags_in_ecr += 1))
     fi
   fi

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -38,7 +38,7 @@ if [ "${PARAM_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${PARAM_SKIP_WHEN_TAGS_EXIST
   fi
 
   if [ -n "$PARAM_EXTRA_BUILD_ARGS" ]; then
-    set -- "$@" "${PARAM_EXTRA_BUILD_ARGS}"
+    set -- "$@" ${PARAM_EXTRA_BUILD_ARGS}
   fi
 
   if [ "${PARAM_PUBLIC_REGISTRY}" == "1" ]; then

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -7,7 +7,6 @@ ECR_COMMAND="ecr"
 number_of_tags_in_ecr=0
 docker_tag_args=""
 
-
 IFS="," read -ra PLATFORMS <<<"${PARAM_PLATFORM}"
 arch_count=${#PLATFORMS[@]}
 
@@ -36,6 +35,13 @@ done
 if [ "${PARAM_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${PARAM_SKIP_WHEN_TAGS_EXIST}" = "1" && ${number_of_tags_in_ecr} -lt ${#DOCKER_TAGS[@]} ]]; then
   if [ "${PARAM_PUSH_IMAGE}" == "1" ]; then
     set -- "$@" --push
+
+    if [ -n "${PARAM_LIFECYCLE_POLICY_PATH}" ]; then
+      aws ecr put-lifecycle-policy \
+        --repository-name "${PARAM_REPO}" \
+        --lifecycle-policy-text "${PARAM_LIFECYCLE_POLICY_PATH}"
+    fi
+
   else
     set -- "$@" --load
   fi

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
-REPO=$(eval echo "${PARAM_REPO}")
-REGION=$(eval echo "${PARAM_REGION}")
-TAG=$(eval echo "${PARAM_TAG}")
-ACCOUNT_URL="${!PARAM_REGISTRY_ID}.dkr.ecr.${REGION}.amazonaws.com"
+PARAM_ACCOUNT_URL="${!PARAM_REGISTRY_ID}.dkr.ecr.${PARAM_REGION}.amazonaws.com"
 ECR_COMMAND="ecr"
 number_of_tags_in_ecr=0
 docker_tag_args=""
@@ -17,24 +14,26 @@ if [ "${PARAM_PUBLIC_REGISTRY}" == "1" ]; then
   fi
 
   ECR_COMMAND="ecr-public"
-  ACCOUNT_URL="public.ecr.aws/${!PARAM_REGISTRY_ID}"
+  PARAM_ACCOUNT_URL="public.ecr.aws/${!PARAM_REGISTRY_ID}"
 fi
 
-IFS="," read -ra DOCKER_TAGS <<<"${TAG}"
+IFS="," read -ra DOCKER_TAGS <<<"${PARAM_TAG}"
 for tag in "${DOCKER_TAGS[@]}"; do
   if [ "${PARAM_SKIP_WHEN_TAGS_EXIST}" = "1" ]; then
-    docker_tag_exists_in_ecr=$(aws "${ECR_COMMAND}" describe-images --profile "${PARAM_PROFILE_NAME}" --registry-id "${!PARAM_REGISTRY_ID}" --region "${REGION}" --repository-name "${REPO}" --query "contains(imageDetails[].imageTags[], '${tag}')")
+    docker_tag_exists_in_ecr=$(aws "${ECR_COMMAND}" describe-images --profile "${PARAM_PROFILE_NAME}" --registry-id "${!PARAM_REGISTRY_ID}" --region "${REGION}" --repository-name "${PARAM_REPO}" --query "contains(imageDetails[].imageTags[], '${tag}')")
     if [ "${docker_tag_exists_in_ecr}" = "1" ]; then
-      docker pull "${ACCOUNT_URL}/${REPO}:${tag}"
+      docker pull "${PARAM_ACCOUNT_URL}/${PARAM_REP}:${tag}"
       number_of_tags_in_ecr=$((number_of_tags_in_ecr += 1))
     fi
   fi
-  docker_tag_args="${docker_tag_args} -t ${ACCOUNT_URL}/${REPO}:${tag}"
+  docker_tag_args="${docker_tag_args} -t ${PARAM_ACCOUNT_URL}/${PARAM_REPO}:${tag}"
 done
 
 if [ "${PARAM_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${PARAM_SKIP_WHEN_TAGS_EXIST}" = "1" && ${number_of_tags_in_ecr} -lt ${#DOCKER_TAGS[@]} ]]; then
   if [ "${PARAM_PUSH_IMAGE}" == "1" ]; then
     set -- "$@" --push
+  else
+    set -- "$@" --load
   fi
 
   if [ -n "$PARAM_EXTRA_BUILD_ARGS" ]; then

--- a/src/scripts/ecr-login.sh
+++ b/src/scripts/ecr-login.sh
@@ -18,3 +18,4 @@ if [ -f ~/.docker/config.json ]; then
 else
     aws "${ECR_COMMAND}" get-login-password --region "${PARAM_REGION}" "$@" | docker login --username AWS --password-stdin "${PARAM_ACCOUNT_URL}"
 fi
+

--- a/src/scripts/ecr-login.sh
+++ b/src/scripts/ecr-login.sh
@@ -11,13 +11,11 @@ fi
 
 if [ -n "${PARAM_PROFILE_NAME}" ]; then
     set -- "$@" --profile "${PARAM_PROFILE_NAME}"
-    echo "$@" >> test.txt
 fi
 
 if [ -f ~/.docker/config.json ]; then
     echo "Credential helper is already installed"
 else
-    echo "aws \"${ECR_COMMAND}\" get-login-password --region \"${PARAM_REGION}\" \"$@\" | docker login --username AWS --password-stdin \"${PARAM_ACCOUNT_URL}\"" >> test.txt
     aws "${ECR_COMMAND}" get-login-password --region "${PARAM_REGION}" "$@" | docker login --username AWS --password-stdin "${PARAM_ACCOUNT_URL}"
 fi
 

--- a/src/scripts/ecr-login.sh
+++ b/src/scripts/ecr-login.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+PARAM_REGION=$(eval echo "${PARAM_REGION}")
 PARAM_ACCOUNT_URL="${!PARAM_REGISTRY_ID}.dkr.ecr.${PARAM_REGION}.amazonaws.com"
 ECR_COMMAND="ecr"
 

--- a/src/scripts/ecr-login.sh
+++ b/src/scripts/ecr-login.sh
@@ -18,4 +18,3 @@ if [ -f ~/.docker/config.json ]; then
 else
     aws "${ECR_COMMAND}" get-login-password --region "${PARAM_REGION}" "$@" | docker login --username AWS --password-stdin "${PARAM_ACCOUNT_URL}"
 fi
-

--- a/src/scripts/ecr-login.sh
+++ b/src/scripts/ecr-login.sh
@@ -11,11 +11,13 @@ fi
 
 if [ -n "${PARAM_PROFILE_NAME}" ]; then
     set -- "$@" --profile "${PARAM_PROFILE_NAME}"
+    echo "$@" >> test.txt
 fi
 
 if [ -f ~/.docker/config.json ]; then
     echo "Credential helper is already installed"
 else
+    echo "aws \"${ECR_COMMAND}\" get-login-password --region \"${PARAM_REGION}\" \"$@\" | docker login --username AWS --password-stdin \"${PARAM_ACCOUNT_URL}\"" >> test.txt
     aws "${ECR_COMMAND}" get-login-password --region "${PARAM_REGION}" "$@" | docker login --username AWS --password-stdin "${PARAM_ACCOUNT_URL}"
 fi
 

--- a/src/scripts/ecr-login.sh
+++ b/src/scripts/ecr-login.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
-REGION=$(eval echo "${PARAM_REGION}")
-ACCOUNT_URL="${!PARAM_REGISTRY_ID}.dkr.ecr.${REGION}.amazonaws.com"
+PARAM_ACCOUNT_URL="${!PARAM_REGISTRY_ID}.dkr.ecr.${PARAM_REGION}.amazonaws.com"
 ECR_COMMAND="ecr"
 
 if [ "$PARAM_PUBLIC_REGISTRY" == "1" ]; then
-    REGION="us-east-1"
-    ACCOUNT_URL="public.ecr.aws"
+    PARAM_REGION="us-east-1"
+    PARAM_ACCOUNT_URL="public.ecr.aws"
     ECR_COMMAND="ecr-public"
 fi
 
@@ -16,5 +15,5 @@ fi
 if [ -f ~/.docker/config.json ]; then
     echo "Credential helper is already installed"
 else
-    aws "${ECR_COMMAND}" get-login-password --region "${REGION}" "$@" | docker login --username AWS --password-stdin "${ACCOUNT_URL}"
+    aws "${ECR_COMMAND}" get-login-password --region "${PARAM_REGION}" "$@" | docker login --username AWS --password-stdin "${PARAM_ACCOUNT_URL}"
 fi

--- a/src/scripts/tag-image.sh
+++ b/src/scripts/tag-image.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
-REPO=$(eval echo "${PARAM_REPO}")
-SOURCE_TAG=$(eval echo "${PARAM_SOURCE_TAG}")
 
 # pull the image manifest from ECR
-MANIFEST=$(aws ecr batch-get-image --repository-name "${REPO}" --image-ids imageTag="${SOURCE_TAG}" --query 'images[].imageManifest' --output text)
+MANIFEST=$(aws ecr batch-get-image --repository-name "${PARAM_REPO}" --image-ids imageTag="${PARAM_SOURCE_TAG}" --query 'images[].imageManifest' --output text)
 IFS="," read -ra ECR_TAGS <<<"${PARAM_TARGET_TAG}"
 for tag in "${ECR_TAGS[@]}"; do
-    aws ecr put-image --repository-name "${REPO}" --image-tag "${tag}" --image-manifest "${MANIFEST}"
+    aws ecr put-image --repository-name "${PARAM_REPO}" --image-tag "${tag}" --image-manifest "${MANIFEST}"
 done

--- a/src/scripts/tag-image.sh
+++ b/src/scripts/tag-image.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 REPO=$(eval echo "${PARAM_REPO}")
+SOURCE_TAG=$(eval echo "${PARAM_SOURCE_TAG}")
 
 # pull the image manifest from ECR
-MANIFEST=$(aws ecr batch-get-image --repository-name "${REPO}" --image-ids imageTag="${PARAM_SOURCE_TAG}" --query 'images[].imageManifest' --output text)
+MANIFEST=$(aws ecr batch-get-image --repository-name "${REPO}" --image-ids imageTag="${SOURCE_TAG}" --query 'images[].imageManifest' --output text)
 IFS="," read -ra ECR_TAGS <<<"${PARAM_TARGET_TAG}"
 for tag in "${ECR_TAGS[@]}"; do
     aws ecr put-image --repository-name "${REPO}" --image-tag "${tag}" --image-manifest "${MANIFEST}"

--- a/src/scripts/tag-image.sh
+++ b/src/scripts/tag-image.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
+PARAM_REPO=$(eval echo "${PARAM_REPO}")
+PARAM_SOURCE_TAG=$(eval echo "${PARAM_SOURCE_TAG}")
 
 # pull the image manifest from ECR
 MANIFEST=$(aws ecr batch-get-image --repository-name "${PARAM_REPO}" --image-ids imageTag="${PARAM_SOURCE_TAG}" --query 'images[].imageManifest' --output text)
 IFS="," read -ra ECR_TAGS <<<"${PARAM_TARGET_TAG}"
 for tag in "${ECR_TAGS[@]}"; do
-    aws ecr put-image --repository-name "${PARAM_REPO}" --image-tag "${tag}" --image-manifest "${MANIFEST}"
+    aws ecr put-image --repository-name "${REPO}" --image-tag "${tag}" --image-manifest "${MANIFEST}"
 done

--- a/src/scripts/tag-image.sh
+++ b/src/scripts/tag-image.sh
@@ -6,5 +6,5 @@ PARAM_SOURCE_TAG=$(eval echo "${PARAM_SOURCE_TAG}")
 MANIFEST=$(aws ecr batch-get-image --repository-name "${PARAM_REPO}" --image-ids imageTag="${PARAM_SOURCE_TAG}" --query 'images[].imageManifest' --output text)
 IFS="," read -ra ECR_TAGS <<<"${PARAM_TARGET_TAG}"
 for tag in "${ECR_TAGS[@]}"; do
-    aws ecr put-image --repository-name "${REPO}" --image-tag "${tag}" --image-manifest "${MANIFEST}"
+    aws ecr put-image --repository-name "${PARAM_REPO}" --image-tag "${tag}" --image-manifest "${MANIFEST}"
 done


### PR DESCRIPTION
## This minor version change addresses the changes:

## Added Commands
**`build-and-push-image`** command was originally removed in `version 8.0` but has been added back by popular demand.


## Added Parameters
**`build-image`** command now supports adding `aws lifecycle policies` to repositories in `ECR`
- `lifecycle-policy-path`:  The path of the .json file containing the aws lifecycle policy. If a path is defined in this parameter, the policy will be attached to the specified `ECR` repository.
- `assume-web-identity`:  A boolean value that lets the user assume a profile with short lived keys. Set to true to configure a profile using short-term credentials

### Issues closed

1. #180 
2. #181 
3. #182
4. #179
5. #188
6. #173 
7. #178  
8. #188 
9. #177 

### PRs merged or addressed:

1.  #184 
2. #183 