### PR TITLE
fix: expand target-tag parameter with eval

### DIFF
--- a/src/scripts/tag-image.sh
+++ b/src/scripts/tag-image.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 PARAM_REPO=$(eval echo "${PARAM_REPO}")
 PARAM_SOURCE_TAG=$(eval echo "${PARAM_SOURCE_TAG}")
+PARAM_TARGET_TAG=$(eval echo "${PARAM_TARGET_TAG}")
 
 # pull the image manifest from ECR
 MANIFEST=$(aws ecr batch-get-image --repository-name "${PARAM_REPO}" --image-ids imageTag="${PARAM_SOURCE_TAG}" --query 'images[].imageManifest' --output text)


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
The `target-tag` parameter would not work with an environment variable.


### Description
I evaluated the parameter with `PARAM_TARGET_TAG=$(eval echo "${PARAM_TARGET_TAG}")`, enabling the use of environment variables.

