### PR TITLE
fix: skip-when-tags-exist not working

### DIFF
--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -24,7 +24,7 @@ IFS="," read -ra DOCKER_TAGS <<<"${PARAM_TAG}"
 for tag in "${DOCKER_TAGS[@]}"; do
   if [ "${PARAM_SKIP_WHEN_TAGS_EXIST}" = "1" ] || [ "${PARAM_SKIP_WHEN_TAGS_EXIST}" = "true" ]; then
     docker_tag_exists_in_ecr=$(aws "${ECR_COMMAND}" describe-images --profile "${PARAM_PROFILE_NAME}" --registry-id "${!PARAM_REGISTRY_ID}" --region "${PARAM_REGION}" --repository-name "${PARAM_REPO}" --query "contains(imageDetails[].imageTags[], '${tag}')")
-    if [ "${docker_tag_exists_in_ecr}" = "1" ]; then
+    if [ "${docker_tag_exists_in_ecr}" = "true" ]; then
       docker pull "${PARAM_ACCOUNT_URL}/${PARAM_REPO}:${tag}"
       number_of_tags_in_ecr=$((number_of_tags_in_ecr += 1))
     fi


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

`skip-when-tags-exist` doesn't work in recent versions of the Orb (confirmed with 8.1.2). When an ECR has immutable tags enabled this is a pretty important feature for image builds to flow smoothly.

### Description

The issue is that a `contains` query in the CLI command to populate `docker_tag_exists_in_ecr`, outputs `true` or `false` and not `1` or `0`, which the test compares against. Changing this to check for `true` means fixes the issue and correctly increments `number_of_tags_in_ecr` if there is a tag already in ECR which will later skip the build.

fixes #200
