### PR TITLE
Fix env var AWS_ACCESS_KEY_ID typo

### DIFF
--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -21,7 +21,7 @@ parameters:
     default: AWS_ACCESS_KEY_ID
     description: >
       AWS access key id for IAM role. Set this to the name of the environment
-      variable you will set to hold this value, i.e. AWS_ACCESS_KEY.
+      variable you will set to hold this value, i.e. AWS_ACCESS_KEY_ID.
     type: env_var_name
 
   aws-secret-access-key:


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

There are two `build-and-push-image` : Command and Job.

The `aws-access-key-id` parameter description has different comments and is inconsistent.

- Command: AWS access key id for IAM role. Set this to the name of the environment variable you will set to hold this value, i.e. AWS_ACCESS_KEY.
- Job: AWS access key id for IAM role. Set this to the name of the environment variable you will set to hold this value, i.e. AWS_ACCESS_KEY_ID.

In this PR, I changed `AWS_ACCESS_KEY` to `AWS_ACCESS_KEY_ID`.

related PR: https://github.com/CircleCI-Public/aws-ecr-orb/pull/96 

I have checked that there is no other part that specifies `AWS_ACCESS_KEY`.
