### PR TITLE
eval PARAM_PATH argument on Docker buildx

### DIFF
--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -2,6 +2,7 @@
 PARAM_REGION=$(eval echo "${PARAM_REGION}")
 PARAM_REPO=$(eval echo "${PARAM_REPO}")
 PARAM_TAG=$(eval echo "${PARAM_TAG}")
+PARAM_PATH=$(eval echo "${PARAM_PATH}")
 PARAM_ACCOUNT_URL="${!PARAM_REGISTRY_ID}.dkr.ecr.${PARAM_REGION}.amazonaws.com"
 ECR_COMMAND="ecr"
 number_of_tags_in_ecr=0


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Per my comment [here](https://github.com/CircleCI-Public/aws-ecr-orb/issues/181#issuecomment-1155589541), it would be great if we could pass a dynamic path name to `build-and-push-image`, in the case where we want to use it for multiple Docker builds within the same config (such as using the `matrix:` style jobs).

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Added an `eval` on the `PARAM_PATH` argument to `buildx`.