### PR TITLE
ADDED - basic retry logic to build-image

### DIFF
--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -208,6 +208,11 @@ parameters:
       Boolean for whether or not to checkout as a first step. Default is true.
     type: boolean
 
+  build-retries:
+    type: integer
+    default: 0
+    description: The number of times to attempt an building and pushing an image
+
 steps:
   - when:
       condition: <<parameters.checkout>>
@@ -282,6 +287,7 @@ steps:
             region: <<parameters.region>>
             public-registry: <<parameters.public-registry>>
             push-image: <<parameters.push-image>>
+            build-retries: <<parameters.build-retries>>
 
   - unless:
       condition:
@@ -304,3 +310,4 @@ steps:
             public-registry: <<parameters.public-registry>>
             push-image: <<parameters.push-image>>
             lifecycle-policy-path: <<parameters.lifecycle-policy-path>>
+            build-retries: <<parameters.build-retries>>

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -78,6 +78,11 @@ parameters:
     description: |
       The path to the .json file containing the lifecycle policy to be applied to a specified repository in AWS ECR.
 
+  retries:
+    type: number
+    default: 0
+    description: The number of times to attempt an taging and pushing an image
+
 steps:
   - run:
       name: Build Docker Image with buildx
@@ -95,5 +100,6 @@ steps:
         PARAM_PUBLIC_REGISTRY: <<parameters.public-registry>>
         PARAM_PUSH_IMAGE: <<parameters.push-image>>
         PARAM_LIFECYCLE_POLICY_PATH: <<parameters.lifecycle-policy-path>>
+        PARAM_RETRIES: <<parameters.retries>>
       command: <<include(scripts/docker-buildx.sh)>>
       no_output_timeout: <<parameters.no-output-timeout>>

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -81,7 +81,7 @@ parameters:
   retries:
     type: integer
     default: 0
-    description: The number of times to attempt an taging and pushing an image
+    description: The number of times to attempt an building and pushing an image
 
 steps:
   - run:

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -83,6 +83,11 @@ parameters:
     default: 0
     description: The number of times to attempt an building and pushing an image
 
+  build_push_timeout:
+    type: integer
+    default: 0
+    description: The amount of time to wait before stopping and retrying, 0=infinite
+
 steps:
   - run:
       name: Build Docker Image with buildx
@@ -101,5 +106,6 @@ steps:
         PARAM_PUSH_IMAGE: <<parameters.push-image>>
         PARAM_LIFECYCLE_POLICY_PATH: <<parameters.lifecycle-policy-path>>
         PARAM_RETRIES: <<parameters.retries>>
+        PARAM_BUILD_PUSH_TIMEOUT: <<parameters.build_push_timeout>>
       command: <<include(scripts/docker-buildx.sh)>>
       no_output_timeout: <<parameters.no-output-timeout>>

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -79,7 +79,7 @@ parameters:
       The path to the .json file containing the lifecycle policy to be applied to a specified repository in AWS ECR.
 
   retries:
-    type: number
+    type: integer
     default: 0
     description: The number of times to attempt an taging and pushing an image
 

--- a/src/examples/simple-build-and-push.yml
+++ b/src/examples/simple-build-and-push.yml
@@ -80,3 +80,7 @@ usage:
             # Set to true if you don't want to build the image if it already exists in the ECR repo, for example when
             # you are tagging with the git commit hash. Specially useful for faster code reverts.
             skip-when-tags-exist: false
+
+            # Set a number other than 0 to add retries to the build-image step.  For use with unstable
+            # connections such as cn-northwest-1
+            build-retries: 3


### PR DESCRIPTION
### Checklist
- [x]  All new jobs, commands, executors, parameters have descriptions
- [x]  Examples have been added for any significant new features
- [x]  README has been updated, if necessary

### Motivation, issues
We find regular connection issues such as `net/http: TLS handshake timeout` when pushing images to the `cn-northwest-1` region.  Retrying generally works so rather than manually retrying jobs we would like this builtin to the orb.

### Description
This creates a `retries` in the `build-image` command.  It defaults to `0` which should make it a transparent change.