### PR TITLE
ADDED - docker login to self-hosted registry

### DIFF
--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -155,6 +155,13 @@ parameters:
       DOCKERHUB_PASSWORD.
     type: env_var_name
 
+  docker-registry:
+    type: string
+    default: ""
+    description: >
+      If you want to login to a self-hosted registry you can specify
+      this by adding the server name.
+
   dockerfile:
     default: Dockerfile
     description: Name of dockerfile to use. Defaults to Dockerfile.
@@ -262,6 +269,7 @@ steps:
         - run: >
             docker login -u $<<parameters.dockerhub-username>> -p
             $<<parameters.dockerhub-password>>
+            <<parameters.docker-registry>>
   - when:
       condition:
         and:

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -162,6 +162,13 @@ parameters:
       the environment variable you will set to hold this
       value, i.e. DOCKERHUB_PASSWORD.
 
+  docker-registry:
+    type: string
+    default: ""
+    description: >
+      If you want to login to a self-hosted registry you can specify
+      this by adding the server name.
+
   dockerfile:
     type: string
     default: Dockerfile
@@ -241,3 +248,4 @@ steps:
       docker-login: <<parameters.docker-login>>
       dockerhub-username: <<parameters.dockerhub-username>>
       dockerhub-password: <<parameters.dockerhub-password>>
+      docker-registry: <<parameters.docker-registry>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
Logging into a self-hosted registry is not possible with the current setup. This PR adds the ability to passing the registry to login to. 
Adds support for this: https://docs.docker.com/engine/reference/commandline/login/#login-to-a-self-hosted-registry

### Description
Added a new parameter `docker-registry` which is passed into the `docker login` command.
