### PR TITLE
Add build-and-push-image command's checkout to job

### DIFF
--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -205,6 +205,12 @@ parameters:
     default: ""
     description: |
       The path to the .json file containing the lifecycle policy to be applied to a specified repository in AWS ECR.
+  
+  checkout:
+    default: true
+    description: |
+      Boolean for whether or not to checkout as a first step of the build-and-push-image command. Default is true.
+    type: boolean
 
 steps:
   - build-and-push-image:
@@ -222,6 +228,7 @@ steps:
       public-registry: <<parameters.public-registry>>
       push-image: <<parameters.push-image>>
       lifecycle-policy-path: <<parameters.lifecycle-policy-path>>
+      checkout: <<parameters.checkout>>
       repo-scan-on-push: <<parameters.repo-scan-on-push>>
       aws-access-key-id: <<parameters.aws-access-key-id>>
       aws-secret-access-key: <<parameters.aws-secret-access-key>>


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features.
- [x] README has been updated, if necessary

### Motivation, issues

Controlling checkout with submodules in Circle is not ideal. The command allows the checkout step to be skipped which then allows `pre-steps:` to be used in the job to configure a more custom checkout procedure.

### Description

Exposes the `checkout` parameter from the `build-and-push-image` command to the job of the same name.
