### PR TITLE
fix: changed static default remote docker version

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -63,7 +63,7 @@ workflows:
           extra-build-args: --compress
           executor: amd64
           role-arn: arn:aws:iam::122211685980:role/CPE_ECR_ADMIN
-          lifecycle-policy-path: ./sample/policy.json
+          lifecycle-policy-path: ./project/sample/policy.json
           post-steps:
             - run:
                 name: "Delete repository"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -63,8 +63,6 @@ workflows:
           extra-build-args: --compress
           executor: amd64
           role-arn: arn:aws:iam::122211685980:role/CPE_ECR_ADMIN
-          source-profile: default
-          new-profile-name: assume-role-test
           lifecycle-policy-path: ./sample/policy.json
           post-steps:
             - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -63,7 +63,7 @@ workflows:
           extra-build-args: --compress
           executor: amd64
           role-arn: arn:aws:iam::122211685980:role/CPE_ECR_ADMIN
-          lifecycle-policy-path: ./project/sample/policy.json
+          lifecycle-policy-path: ./sample/policy.json
           post-steps:
             - run:
                 name: "Delete repository"

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -122,7 +122,7 @@ parameters:
     type: boolean
 
   remote-docker-version:
-    default: 19.03.13
+    default: ""
     description: Specific remote docker version
     type: string
 

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -130,7 +130,7 @@ parameters:
 
   remote-docker-version:
     type: string
-    default: 19.03.13
+    default: ""
     description: Specific remote docker version
 
   remote-docker-layer-caching:

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -39,7 +39,7 @@ if [ "${PARAM_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${PARAM_SKIP_WHEN_TAGS_EXIST
     if [ -n "${PARAM_LIFECYCLE_POLICY_PATH}" ]; then
       aws ecr put-lifecycle-policy \
         --repository-name "${PARAM_REPO}" \
-        --lifecycle-policy-text "${PARAM_LIFECYCLE_POLICY_PATH}"
+        --lifecycle-policy-text "file://${PARAM_LIFECYCLE_POLICY_PATH}"
     fi
 
   else


### PR DESCRIPTION
This `PR` changes the default value for the `version` parameter in the `setup_remote_docker` command to an empty string.

As of September 6th, if there is no version specified, the `setup_remote_docker` command will use the latest `default` version that's updated on a rolling basis.

More info can be found here: https://discuss.circleci.com/t/default-docker-version-for-remote-docker-jobs-changing-on-september-6/45157/2