### PR TITLE
fix: Support environment variables in the path parameter

### DIFF
--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -2,6 +2,7 @@
 PARAM_REGION=$(eval echo "${PARAM_REGION}")
 PARAM_REPO=$(eval echo "${PARAM_REPO}")
 PARAM_TAG=$(eval echo "${PARAM_TAG}")
+PARAM_PATH=$(eval echo "${PARAM_PATH}")
 PARAM_ACCOUNT_URL="${!PARAM_REGISTRY_ID}.dkr.ecr.${PARAM_REGION}.amazonaws.com"
 ECR_COMMAND="ecr"
 number_of_tags_in_ecr=0


### PR DESCRIPTION

### Checklist

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues
Solves https://github.com/CircleCI-Public/aws-ecr-orb/issues/231

### Description

Supports using environment variables in the path parameter of the `build-image` command.
