### PR TITLE
Conditionally run uninstall command when remote docker layer caching…

### DIFF
--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -290,6 +290,7 @@ steps:
             public-registry: <<parameters.public-registry>>
             push-image: <<parameters.push-image>>
             public-registry-alias: <<parameters.public-registry-alias>>
+            remote-docker-layer-caching: <<parameters.remote-docker-layer-caching>>
 
   - unless:
       condition:

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -85,6 +85,13 @@ parameters:
     description: |
       The path to the .json file containing the lifecycle policy to be applied to a specified repository in AWS ECR.
 
+  remote-docker-layer-caching:
+    default: false
+    description: >
+      Enable Docker layer caching if using remote Docker engine. Defaults to
+      false.
+    type: boolean
+
 steps:
   - run:
       name: Build Docker Image with buildx
@@ -104,4 +111,13 @@ steps:
         ORB_VAL_LIFECYCLE_POLICY_PATH: <<parameters.lifecycle-policy-path>>
         ORB_EVAL_PUBLIC_REGISTRY_ALIAS: <<parameters.public-registry-alias>>
       command: <<include(scripts/docker-buildx.sh)>>
+      no_output_timeout: <<parameters.no-output-timeout>>
+  - run:
+      name: Clean up multi-architecture image build artifacts
+      environment:
+      when:
+        condition:
+          and:
+            - equal: [ true, <<parameters.remote-docker-layer-caching>> ]
+      command: <<include(scripts/docker-buildx-cleanup.sh)>>
       no_output_timeout: <<parameters.no-output-timeout>>

--- a/src/examples/multi-arch-build.yml
+++ b/src/examples/multi-arch-build.yml
@@ -1,0 +1,82 @@
+description: Log into AWS, build multi-architecture image and push to ECR
+
+usage:
+  version: 2.1
+
+  orbs:
+    aws-ecr: circleci/aws-ecr@x.y
+
+  workflows:
+    build_and_push_image:
+      jobs:
+        # build and push image to ECR
+        - aws-ecr/build-and-push-image:
+            # Select executor defined above
+            executor: aws-ecr/default
+
+            # name of your ECR repository
+            repo: myECRRepository
+
+            # set this to true to create the repository if it does not already exist, defaults to "false"
+            create-repo: true
+
+            # required if any necessary secrets are stored via Contexts
+            context: myContext
+
+            # AWS profile name, defaults to "default"
+            profile-name: myProfileName
+
+            # name of env var storing your AWS Access Key ID, defaults to AWS_ACCESS_KEY_ID
+            aws-access-key-id: ACCESS_KEY_ID_ENV_VAR_NAME
+
+            # name of env var storing your AWS Secret Access Key, defaults to AWS_SECRET_ACCESS_KEY
+            aws-secret-access-key: SECRET_ACCESS_KEY_ENV_VAR_NAME
+
+            # Name of new profile associated with role arn.
+            new-profile-name: newProfileName
+
+            # Source profile containing credentials to assume the role with role-arn.
+            source-profile: sourceProfileName
+
+            # Role ARN that new profile should take
+            role-arn: arn:aws:iam::123456789012:role/testing
+
+            #Your AWS region
+            region: AWS_REGION
+
+            # name of env var storing your ECR Registry ID
+            registry-id: AWS_ECR_REGISTRY_ID
+
+            # ECR image tags (comma separated string), defaults to "latest"
+            tag: latest,myECRRepoTag
+
+            # name of Dockerfile to use, defaults to "Dockerfile"
+            dockerfile: myDockerfile
+
+            # path to Dockerfile, defaults to . (working directory)
+            path: pathToMyDockerfile
+
+            # Select a specific version of the AWS v2 CLI. By default the latest version will be used.
+            aws-cli-version: latest
+
+            # Boolean value if pushing to public registry. Defaults to true.
+            public-registry: false
+
+            # Security scans repository on push.  Defaults to true.
+            repo-scan-on-push: true
+
+            # The amount of time to allow the docker build command to run before timing out, defaults to "10m"
+            no-output-timeout: 20m
+
+            # Extra docker buildx build arguments
+            extra-build-args: --compress
+
+            # Specify platform targets (comma separated string) for built docker image.
+            platform: linux/amd64,linux/arm64
+
+            # Push image to repository after building.  Defaults to true
+            push-image: true
+
+            # Set to true if you don't want to build the image if it already exists in the ECR repo, for example when
+            # you are tagging with the git commit hash. Specially useful for faster code reverts.
+            skip-when-tags-exist: false

--- a/src/scripts/docker-buildx-cleanup.sh
+++ b/src/scripts/docker-buildx-cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# to prevent filesystem corruption, clean up multi-arch binary format handlers from the host prior to
+# saving updated cache
+docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-*


### PR DESCRIPTION
… is used

### Checklist
- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
Currently, when remote docker is used with the latest iteration of Docker Layer Caching (DLC), a multi-architecture build can leave filesystem entries behind that cause corruption upon saving the layer cache. Invoking `docker run --privileged --rm tonistiigi/binfmt --install all` as part of the buildx context creation registers various `qemu`-based binary format hooks on the host system. If these are not cleaned up prior to saving the `/var/lib/docker` layer cache, the resulting ext4 filesystem is considered corrupt due to missing links.

The fix proposed here is to conditionally (i.e. if `remote-docker-layer-caching` is provided in the parameters) invoke `docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-*` to remove the `qemu` binary format handlers prior to the end of the workflow to preserve a valid state of the filesystem for caching.

The current proposal has opted to put this single command into a standalone script file, though I think the case could be made to simply use the single step instead. I'll leave it up to the reviewers for the final decision on that.

### Description
- add conditional `Clean up multi-architecture image build artifacts` step to `build-image` job
  - propagate `remote-docker-layer-caching` parameter from the parent `build-and-push-image` job definition
