### PR TITLE
feat: added push-image command

### DIFF
--- a/src/commands/push-image.yml
+++ b/src/commands/push-image.yml
@@ -37,4 +37,5 @@ steps:
         ORB_EVAL_TAG: << parameters.tag >>
         ORB_VAL_PUBLIC_REGISTRY: <<parameters.public-registry>>
         ORB_EVAL_PUBLIC_REGISTRY_ALIAS: <<parameters.public-registry-alias>>
+        ORB_ENV_REGISTRY_ID: << parameters.registry-id >>
       command: << include(scripts/push-image.sh) >>

--- a/src/commands/push-image.yml
+++ b/src/commands/push-image.yml
@@ -18,6 +18,16 @@ parameters:
     default: latest
     description: A comma-separated string containing docker image tags (default = latest)
     type: string
+  public-registry:
+    type: boolean
+    description: Set to true if building and pushing an image to a Public Registry on ECR.
+    default: false
+  public-registry-alias:
+    type: string
+    default: ${AWS_ECR_PUBLIC_REGISTRY_ALIAS}
+    description: >
+      The public registry alias for your public repositories. This parameter is required if pushing to a public repository
+      It can be found in the Amazon ECR console > Public Registries.
 steps:
   - run:
       name: Push image to AWS ECR
@@ -25,4 +35,6 @@ steps:
         ORB_EVAL_REPO: << parameters.repo >>
         ORB_EVAL_REGION: << parameters.region >>
         ORB_EVAL_TAG: << parameters.tag >>
+        ORB_VAL_PUBLIC_REGISTRY: <<parameters.public-registry>>
+        ORB_EVAL_PUBLIC_REGISTRY_ALIAS: <<parameters.public-registry-alias>>
       command: << include(scripts/push-image.sh) >>

--- a/src/commands/push-image.yml
+++ b/src/commands/push-image.yml
@@ -19,9 +19,10 @@ parameters:
     description: A comma-separated string containing docker image tags (default = latest)
     type: string
 steps:
-  name: Push image to AWS ECR
-  environment:
-    ORB_EVAL_REPO: << parameters.repo >>
-    ORB_EVAL_REGION: << parameters.region >>
-    ORB_EVAL_TAG: << parameters.tag >>
-  command: << include(scripts/push-image.sh) >>
+  - run:
+      name: Push image to AWS ECR
+      environment:
+        ORB_EVAL_REPO: << parameters.repo >>
+        ORB_EVAL_REGION: << parameters.region >>
+        ORB_EVAL_TAG: << parameters.tag >>
+      command: << include(scripts/push-image.sh) >>

--- a/src/commands/push-image.yml
+++ b/src/commands/push-image.yml
@@ -10,13 +10,13 @@ parameters:
     type: string
     default: ${AWS_REGION}
     description: >
-      AWS region of ECR repository. Defaults to environment variable ${AWS_REGION}      
+      AWS region of ECR repository. Defaults to environment variable ${AWS_REGION}
   repo:
     description: Name of an Amazon ECR repository
     type: string
   tag:
     default: latest
-    description: A comma-separated string containing docker image tags (default = latest)    
+    description: A comma-separated string containing docker image tags (default = latest)
     type: string
 steps:
   name: Push image to AWS ECR
@@ -24,4 +24,4 @@ steps:
     ORB_EVAL_REPO: << parameters.repo >>
     ORB_EVAL_REGION: << parameters.region >>
     ORB_EVAL_TAG: << parameters.tag >>
-  command: << include(src/push-image.sh) >>  
+  command: << include(scripts/push-image.sh) >>

--- a/src/commands/push-image.yml
+++ b/src/commands/push-image.yml
@@ -1,0 +1,27 @@
+description: Push a container image to the Amazon ECR registry
+parameters:
+  registry-id:
+    type: env_var_name
+    default: AWS_ECR_REGISTRY_ID
+    description: >
+      The 12 digit AWS Registry ID associated with the ECR account.
+      This field is required
+  region:
+    type: string
+    default: ${AWS_REGION}
+    description: >
+      AWS region of ECR repository. Defaults to environment variable ${AWS_REGION}      
+  repo:
+    description: Name of an Amazon ECR repository
+    type: string
+  tag:
+    default: latest
+    description: A comma-separated string containing docker image tags (default = latest)    
+    type: string
+steps:
+  name: Push image to AWS ECR
+  environment:
+    ORB_EVAL_REPO: << parameters.repo >>
+    ORB_EVAL_REGION: << parameters.region >>
+    ORB_EVAL_TAG: << parameters.tag >>
+  command: << include(src/push-image.sh) >>  

--- a/src/scripts/push-image.sh
+++ b/src/scripts/push-image.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
-ORB_VAL_ACCOUNT_URL=$(eval echo "${ORB_ENV_REGISTRY_ID}.dkr.ecr.${ORB_EVAL_REGION}.amazonaws.com")
 ORB_EVAL_REPO=$(eval echo "${ORB_EVAL_REPO}")
 ORB_EVAL_TAG=$(eval echo "${ORB_EVAL_TAG}")
+ORB_EVAL_REGION=$(eval echo "${ORB_EVAL_REGION}")
+ORB_VAL_ACCOUNT_URL="${!ORB_ENV_REGISTRY_ID}.dkr.ecr.${ORB_EVAL_REGION}.amazonaws.com"
+ORB_EVAL_PUBLIC_REGISTRY_ALIAS=$(eval echo "${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}")
+
+if [ "${ORB_VAL_PUBLIC_REGISTRY}" == "1" ]; then
+  ORB_VAL_ACCOUNT_URL="public.ecr.aws/${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}"
+fi
 
 IFS="," read -ra DOCKER_TAGS <<< "${ORB_EVAL_TAG}"
 for tag in "${DOCKER_TAGS[@]}"; do

--- a/src/scripts/push-image.sh
+++ b/src/scripts/push-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ORB_VAL_ACCOUNT_URL="${ORB_ENV_REGISTRY_ID}.dkr.ecr.${ORB_EVAL_REGION}.amazonaws.com"
+ORB_VAL_ACCOUNT_URL=$(eval echo "${ORB_ENV_REGISTRY_ID}.dkr.ecr.${ORB_EVAL_REGION}.amazonaws.com")
 ORB_EVAL_REPO=$(eval echo "${ORB_EVAL_REPO}")
 ORB_EVAL_TAG=$(eval echo "${ORB_EVAL_TAG}")
 

--- a/src/scripts/push-image.sh
+++ b/src/scripts/push-image.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+ORB_VAL_ACCOUNT_URL="${ORB_ENV_REGISTRY_ID}.dkr.ecr.${ORB_EVAL_REGION}.amazonaws.com"
+ORB_EVAL_REPO=$(eval echo "${ORB_EVAL_REPO}")
+ORB_EVAL_TAG=$(eval echo "${ORB_EVAL_TAG}")
+
+IFS="," read -ra DOCKER_TAGS <<< "${ORB_EVAL_TAG}"
+for tag in "${DOCKER_TAGS[@]}"; do
+    docker push "${ORB_VAL_ACCOUNT_URL}/${ORB_EVAL_REPO}:${tag}"
+done


### PR DESCRIPTION
This `PR` adds the `push-image` command to the `aws ecr` orb, enabling customers to push images that have been built outside of the `docker build` command 