### PR TITLE
feat: Add dockerfile_path parameter to commands and docker-buildx.sh

### DIFF
--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -167,6 +167,13 @@ parameters:
       Defaults to . (working directory).
     type: string
 
+  dockerfile_path:
+    default: .
+    description: >-
+      Path to the directory containing your Dockerfile. Use when the dockerfile is in a different location than the 
+      build directory. Defaults to . (working directory).
+    type: string
+
   extra-build-args:
     default: ""
     description: >
@@ -281,6 +288,7 @@ steps:
             tag: <<parameters.tag>>
             dockerfile: <<parameters.dockerfile>>
             path: <<parameters.path>>
+            dockerfile_path: <<parameters.dockerfile_path>>
             extra-build-args: <<parameters.extra-build-args>>
             no-output-timeout: <<parameters.no-output-timeout>>
             skip-when-tags-exist: <<parameters.skip-when-tags-exist>>
@@ -303,6 +311,7 @@ steps:
             tag: <<parameters.tag>>
             dockerfile: <<parameters.dockerfile>>
             path: <<parameters.path>>
+            dockerfile_path: <<parameters.dockerfile_path>>
             extra-build-args: <<parameters.extra-build-args>>
             no-output-timeout: <<parameters.no-output-timeout>>
             skip-when-tags-exist: <<parameters.skip-when-tags-exist>>

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -27,6 +27,13 @@ parameters:
     default: .
     description: Path to the directory containing your Dockerfile and build context. Defaults to . (working directory).
 
+  dockerfile_path:
+    default: .
+    description: >-
+      Path to the directory containing your Dockerfile. Use when the dockerfile is in a different location than the 
+      build directory. Defaults to . (working directory).
+    type: string
+
   no-output-timeout:
     type: string
     default: 10m
@@ -94,6 +101,7 @@ steps:
         ORB_EVAL_REPO: << parameters.repo >>
         ORB_VAL_EXTRA_BUILD_ARGS: <<parameters.extra-build-args>>
         ORB_EVAL_PATH: <<parameters.path>>
+        ORB_EVAL_DOCKERFILE_PATH: <<parameters.dockerfile_path>>
         ORB_VAL_DOCKERFILE: <<parameters.dockerfile>>
         ORB_VAL_PROFILE_NAME: <<parameters.profile-name>>
         ORB_ENV_REGISTRY_ID: <<parameters.registry-id>>

--- a/src/examples/simple-build-and-push.yml
+++ b/src/examples/simple-build-and-push.yml
@@ -53,8 +53,12 @@ usage:
             # name of Dockerfile to use, defaults to "Dockerfile"
             dockerfile: myDockerfile
 
-            # path to Dockerfile, defaults to . (working directory)
-            path: pathToMyDockerfile
+            # path to build directory which is assumed to contain dockerfile if dockerfile_path is unused, defaults
+            # to . (working directory)
+            path: pathToMyBuildDirectory
+
+            # path to dockerfile, defaults to . (working directory)
+            dockerfile_path: pathToMyDockerfile
 
             # Select a specific version of the AWS v2 CLI. By default the latest version will be used.
             aws-cli-version: latest

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -172,6 +172,13 @@ parameters:
     default: .
     description: Path to the directory containing your Dockerfile and build context. Defaults to . (working directory).
 
+  dockerfile_path:
+    type: string
+    default: .
+    description: >-
+      Path to the directory containing your Dockerfile. Use when the dockerfile is in a different location than the 
+      build directory. Defaults to . (working directory). 
+
   extra-build-args:
     type: string
     default: ""

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -3,11 +3,17 @@ ORB_EVAL_REGION=$(eval echo "${ORB_EVAL_REGION}")
 ORB_EVAL_REPO=$(eval echo "${ORB_EVAL_REPO}")
 ORB_EVAL_TAG=$(eval echo "${ORB_EVAL_TAG}")
 ORB_EVAL_PATH=$(eval echo "${ORB_EVAL_PATH}")
+ORB_EVAL_DOCKERFILE_PATH=$(eval echo "${ORB_EVAL_DOCKERFILE_PATH}")
 ORB_VAL_ACCOUNT_URL="${!ORB_ENV_REGISTRY_ID}.dkr.ecr.${ORB_EVAL_REGION}.amazonaws.com"
 ORB_EVAL_PUBLIC_REGISTRY_ALIAS=$(eval echo "${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}")
 ECR_COMMAND="ecr"
 number_of_tags_in_ecr=0
 docker_tag_args=""
+
+dockerfile_path=$ORB_EVAL_PATH
+if [ "${ORB_EVAL_DOCKERFILE_PATH}" != "." ]; then
+  dockerfile_path=$ORB_EVAL_DOCKERFILE_PATH
+fi
 
 IFS="," read -ra PLATFORMS <<<"${ORB_VAL_PLATFORM}"
 arch_count=${#PLATFORMS[@]}
@@ -55,7 +61,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
 
   if [ "${ORB_VAL_PUBLIC_REGISTRY}" == "1" ]; then
     docker buildx build \
-      -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
+      -f "${dockerfile_path}"/"${ORB_VAL_DOCKERFILE}" \
       ${docker_tag_args} \
       --platform "${ORB_VAL_PLATFORM}" \
       --progress plain \
@@ -73,7 +79,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     fi
 
     docker --context builder buildx build \
-      -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
+      -f "${dockerfile_path}"/"${ORB_VAL_DOCKERFILE}" \
       ${docker_tag_args} \
       --platform "${ORB_VAL_PLATFORM}" \
       --progress plain \


### PR DESCRIPTION
### Description
This PR adds a new parameter to the commands contained in this orb: `dockerfile_path`. Please see motivation on why I think this should be added.

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
This is useful in cases where the dockerfile location differs from the build directory.

Consider a directory:

```
.
├── docker
│   └── Dockerfile
├── requirements.txt
└── src
    └── stuff.py
```

At the cli you can run, from `.` :
```
docker build -f docker/Dockerfile .
```
Works fine. The current Orb equivalent is to try:

```
- aws-ecr/build-and-push-image: 
	...
	path: ./docker
```

But that will cause the build script within to run
```
docker build -f docker/Dockerfile ./docker
```

Which isn't what you want. So there isn't a way to split the 'build directory' from the directory holding the dockerfile itself, unless you use extra-build-args, which knocks out some convenience of this orb:

```
- aws-ecr/build-and-push-image:
	...
	extra-build-args: '-f docker/Dockerfile'
	# path: not used at all
	# dockerfile: not used at all
```

#### Relevant issues
- My own issue, which caused me to search for other GH issues to see if others had solved this.
- https://github.com/CircleCI-Public/aws-ecr-orb/issues/220

### Maintainer questions:
I struggled with the language on 'build directory' vs ...'directory containing the dockerfile'. I'm making up that 'build directory' phrase but it seems correct? I think the language is a little confusing how I have it and welcome suggestion to clarify it.

Also please check the bash changes. I can hardly write bash, much less idiomatic bash.