### PR TITLE
feat: Add set-repository-permissions

### DIFF
--- a/sample/repo-policy.json
+++ b/sample/repo-policy.json
@@ -1,0 +1,17 @@
+{
+    "Version": "2008-10-17",
+    "Statement": [
+      {
+        "Sid": "Allow Sample Account 123456789012",
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": [
+            "arn:aws:iam::123456789012:root"
+          ]
+        },
+        "Action": [
+          "ecr:*"
+        ]
+      }
+    ]
+  }

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -215,6 +215,17 @@ parameters:
       Boolean for whether or not to checkout as a first step. Default is true.
     type: boolean
 
+  set-repo-policy:
+    default: false
+    description: Should a repository policy be set?
+    type: boolean
+
+  repo-policy-path:
+    type: string
+    default: ""
+    description: |
+      The path to the .json file containing the repository policy to be applied to a specified repository in AWS ECR.
+
 steps:
   - when:
       condition: <<parameters.checkout>>
@@ -262,6 +273,16 @@ steps:
             repo: <<parameters.repo>>
             repo-scan-on-push: <<parameters.repo-scan-on-push>>
             public-registry: <<parameters.public-registry>>
+
+  - when:
+      condition: <<parameters.set-repo-policy>>
+      steps:
+        - set-repo-policy:
+            profile-name: <<parameters.profile-name>>
+            region: <<parameters.region>>
+            repo: <<parameters.repo>>
+            public-registry: <<parameters.public-registry>>
+            repo-policy-path: <<parameters.repo-policy-path>>
 
   - when:
       condition: <<parameters.docker-login>>

--- a/src/commands/set-repo-policy.yml
+++ b/src/commands/set-repo-policy.yml
@@ -1,0 +1,39 @@
+description: Sets a repository policy on a AWS ECR repository.
+
+parameters:
+  profile-name:
+    type: string
+    default: "default"
+    description: AWS profile name to be configured.
+
+  region:
+    type: string
+    default: ${AWS_REGION}
+    description: >
+      AWS region of ECR repository. Defaults to environment variable ${AWS_REGION}
+
+  repo:
+    type: string
+    description: Name of an Amazon ECR repository
+
+  public-registry:
+    type: boolean
+    description: Set to true if building and pushing an image to a Public Registry on ECR.
+    default: false
+
+  repo-policy-path:
+    type: string
+    default: ""
+    description: |
+      The path to the .json file containing the repository policy to be applied to a specified repository in AWS ECR.
+
+steps:
+  - run:
+      name: Set Repository Policy
+      environment:
+        ORB_VAL_PROFILE_NAME: <<parameters.profile-name>>
+        ORB_EVAL_REGION: <<parameters.region>>
+        ORB_EVAL_REPO: <<parameters.repo>>
+        ORB_VAL_PUBLIC_REGISTRY: <<parameters.public-registry>>
+        ORB_VAL_REPO_POLICY_PATH: <<parameters.repo-policy-path>>
+      command: <<include(scripts/set-repo-policy.sh)>>

--- a/src/examples/simple-build-and-push.yml
+++ b/src/examples/simple-build-and-push.yml
@@ -80,3 +80,9 @@ usage:
             # Set to true if you don't want to build the image if it already exists in the ECR repo, for example when
             # you are tagging with the git commit hash. Specially useful for faster code reverts.
             skip-when-tags-exist: false
+
+            # set this along wih `repo-policy-path` to true to set a repository policy, defaults to "false"
+            set-repo-policy: true
+
+            # requires `set-repo-policy: true`, pass in a file with the repo permissions policy
+            repo-policy-path: repo-policy.json

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -213,6 +213,17 @@ parameters:
     description: |
       The path to the .json file containing the lifecycle policy to be applied to a specified repository in AWS ECR.
 
+  set-repo-policy:
+    default: false
+    description: Should a repository policy be set?
+    type: boolean
+
+  repo-policy-path:
+    type: string
+    default: ""
+    description: |
+      The path to the .json file containing the repository policy to be applied to a specified repository in AWS ECR.
+
 steps:
   - build-and-push-image:
       registry-id: <<parameters.registry-id>>
@@ -249,3 +260,5 @@ steps:
       dockerhub-username: <<parameters.dockerhub-username>>
       dockerhub-password: <<parameters.dockerhub-password>>
       public-registry-alias: <<parameters.public-registry-alias>>
+      set-repo-policy: <<parameters.set-repo-policy>>
+      repo-policy-path: <<parameters.repo-policy-path>>

--- a/src/scripts/set-repo-policy.sh
+++ b/src/scripts/set-repo-policy.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+ORB_EVAL_REGION=$(eval echo "${ORB_EVAL_REGION}")
+ORB_EVAL_REPO=$(eval echo "${ORB_EVAL_REPO}")
+
+if [ "$ORB_VAL_PUBLIC_REGISTRY" == "1" ]; then
+    echo "set-repository-policy is not supported on public repos"
+    exit 1
+else
+    aws ecr set-repository-policy \
+        --profile "${ORB_VAL_PROFILE_NAME}" \
+        --region "${ORB_EVAL_REGION}" \
+        --repository-name "${ORB_EVAL_REPO}" \
+        --policy-text "file://${ORB_VAL_REPO_POLICY_PATH}"
+fi


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

This builds on the with the existing `create-repo` parameter by allowing a user to also set an ECR repository policy.  This solves situations where AWS multi-account access is required and must be set outside of this orb before the repository is fully functional.

### Description

Adds a new boolean `set-repo-policy` and a new script `set-repo-policy.sh` calling [aws ecr set-repository-policy ](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ecr/set-repository-policy.html).