### PR TITLE
fix: remove binfmt install before docker layer caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ workflows:
           orb-name: circleci/aws-ecr
           vcs-type: << pipeline.project.type >>
           requires:
-            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
+            [orb-tools/pack, shellcheck/check]
           # Use a context to hold your publishing token.
           github-token: GHI_TOKEN
           context: orb-publisher

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -91,10 +91,10 @@ workflows:
           extra-build-args: --compress
           executor: amd64
           public-registry: true
-          # post-steps:
-          #   - run:
-          #       name: "Delete repository"
-          #       command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry --force
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: aws ecr-public delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry --force
           platform: linux/amd64,linux/arm64
           filters:
             tags:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -78,7 +78,7 @@ workflows:
           name: integration-tests-pubic-registry
           attach-workspace: true
           workspace-root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registrys
           create-repo: true
           role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           region: "us-west-2"
@@ -96,7 +96,7 @@ workflows:
           post-steps:
             - run:
                 name: "Delete repository"
-                command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry --force
+                command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registrys --force
           platform: linux/amd64
           filters:
             tags:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -91,7 +91,7 @@ workflows:
           extra-build-args: "--compress"
           executor: amd64
           public-registry: true
-          # remote-docker-layer-caching: true
+          remote-docker-layer-caching: true
           # setup-remote-docker: true
           post-steps:
             - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -97,7 +97,7 @@ workflows:
             - run:
                 name: "Delete repository"
                 command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registrys --force
-          platform: linux/amd64
+          platform: linux/arm64
           filters:
             tags:
               only: /.*/

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -89,15 +89,15 @@ workflows:
           dockerfile: sample/Dockerfile
           path: workspace
           extra-build-args: "--compress"
-          executor: amd64
+          executor: arm64
           public-registry: true
+          platform: linux/arm64
           # remote-docker-layer-caching: true
           # setup-remote-docker: true
           post-steps:
             - run:
                 name: "Delete repository"
                 command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registrys --force
-          platform: linux/arm64
           filters:
             tags:
               only: /.*/

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -75,7 +75,7 @@ workflows:
       #     requires: [pre-integration]
 
       - aws-ecr/build-and-push-image:
-          pre-step:
+          pre-steps:
             - run:
                 name: "Export env_var"
                 command: echo 'export VAR="--compress"' >> "$BASH_ENV"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -86,8 +86,8 @@ workflows:
           profile-name: "OIDC-User"
           context: [CPE-OIDC]
           tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
+          dockerfile: Dockerfile
+          path: ./sample
           extra-build-args: "--compress"
           executor: amd64
           public-registry: true

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -75,6 +75,10 @@ workflows:
       #     requires: [pre-integration]
 
       - aws-ecr/build-and-push-image:
+          pre-step:
+            - run:
+                name: "Export env_var"
+                command: echo 'export VAR="--compress"' >> "$BASH_ENV"
           name: integration-tests-pubic-registry
           attach-workspace: true
           workspace-root: workspace
@@ -88,10 +92,10 @@ workflows:
           tag: integration,myECRRepoTag
           dockerfile: Dockerfile
           path: ./sample
-          extra-build-args: "--compress"
+          extra-build-args: '${VAR}'
           executor: amd64
           public-registry: true
-          platform: linux/arm64,linux/amd64
+          platform: linux/arm64
           # remote-docker-layer-caching: true
           # setup-remote-docker: true
           post-steps:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -236,9 +236,9 @@ executors:
     machine:
       image: ubuntu-2204:2022.07.1
     resource_class: medium
-    docker_layer_caching: <<parameters.remote-docker-layer-caching>>
+    # docker_layer_caching: <<parameters.remote-docker-layer-caching>>
   arm64:
     machine:
       image: ubuntu-2204:2022.07.1
     resource_class: arm.medium
-    docker_layer_caching: <<parameters.remote-docker-layer-caching>>
+    # docker_layer_caching: <<parameters.remote-docker-layer-caching>>

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -91,8 +91,8 @@ workflows:
           extra-build-args: "--compress"
           executor: amd64
           public-registry: true
-          remote-docker-layer-caching: true
-          setup-remote-docker: true
+          # remote-docker-layer-caching: true
+          # setup-remote-docker: true
           post-steps:
             - run:
                 name: "Delete repository"
@@ -236,6 +236,7 @@ executors:
   amd64:
     machine:
       image: ubuntu-2204:2022.07.1
+      docker_layer_caching: <<parameters.remote-docker-layer-caching>>
     resource_class: medium
   arm64:
     machine:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -94,10 +94,10 @@ workflows:
           platform: linux/arm64
           # remote-docker-layer-caching: true
           # setup-remote-docker: true
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registrys --force
+          # post-steps:
+          #   - run:
+          #       name: "Delete repository"
+          #       command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registrys --force
           filters:
             tags:
               only: /.*/

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -91,10 +91,10 @@ workflows:
           extra-build-args: --compress
           executor: amd64
           public-registry: true
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry --force
+          # post-steps:
+          #   - run:
+          #       name: "Delete repository"
+          #       command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry --force
           platform: linux/amd64,linux/arm64
           filters:
             tags:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -50,29 +50,29 @@ workflows:
             tags:
               only: /.*/
 
-      - aws-ecr/build-and-push-image:
-          name: integration-tests-default-profile
-          attach-workspace: true
-          workspace-root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
-          create-repo: true
-          context: [CPE_ORBS_AWS]
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra-build-args: --compress
-          executor: amd64
-          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_ADMIN
-          lifecycle-policy-path: ./sample/policy.json
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile --force
-          platform: linux/amd64,linux/arm64
-          filters:
-            tags:
-              only: /.*/
-          requires: [pre-integration]
+      # - aws-ecr/build-and-push-image:
+      #     name: integration-tests-default-profile
+      #     attach-workspace: true
+      #     workspace-root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
+      #     create-repo: true
+      #     context: [CPE_ORBS_AWS]
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra-build-args: --compress
+      #     executor: amd64
+      #     role-arn: arn:aws:iam::122211685980:role/CPE_ECR_ADMIN
+      #     lifecycle-policy-path: ./sample/policy.json
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile --force
+      #     platform: linux/amd64,linux/arm64
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #     requires: [pre-integration]
 
       - aws-ecr/build-and-push-image:
           name: integration-tests-pubic-registry
@@ -95,107 +95,107 @@ workflows:
             - run:
                 name: "Delete repository"
                 command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry --force
-          platform: linux/amd64
+          platform: linux/amd64,linux/arm64
           filters:
             tags:
               only: /.*/
           requires: [pre-integration]
 
-      - aws-ecr/build-and-push-image:
-          name: integration-tests-named-profile
-          attach-workspace: true
-          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          region: "us-west-2"
-          assume-web-identity: true
-          profile-name: "OIDC-User"
-          context: [CPE-OIDC]
-          workspace-root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-          create-repo: true
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra-build-args: --compress
-          executor: amd64
-          filters:
-            tags:
-              only: /.*/
-          requires: [pre-integration]
+      # - aws-ecr/build-and-push-image:
+      #     name: integration-tests-named-profile
+      #     attach-workspace: true
+      #     role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     region: "us-west-2"
+      #     assume-web-identity: true
+      #     profile-name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     workspace-root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+      #     create-repo: true
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra-build-args: --compress
+      #     executor: amd64
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #     requires: [pre-integration]
 
-      - tag-ecr-image:
-          name: integration-tests-tag-existing-image
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          region: "us-west-2"
-          assume-web-identity: true
-          profile-name: "OIDC-User"
-          context: [CPE-OIDC]
-          source-tag: integration
-          target-tag: latest
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile --force
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - integration-tests-named-profile
+      # - tag-ecr-image:
+      #     name: integration-tests-tag-existing-image
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+      #     role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     region: "us-west-2"
+      #     assume-web-identity: true
+      #     profile-name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     source-tag: integration
+      #     target-tag: latest
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile --force
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #     requires:
+      #       - integration-tests-named-profile
 
-      - aws-ecr/build-and-push-image:
-          name: integration-tests-skip-when-tags-exist-populate-image-<<matrix.executor>>
-          attach-workspace: true
-          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          region: "us-west-2"
-          assume-web-identity: true
-          profile-name: "OIDC-User"
-          context: [CPE-OIDC]
-          workspace-root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
-          create-repo: true
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra-build-args: --compress
-          skip-when-tags-exist: true
-          matrix:
-            parameters:
-              executor: ["amd64", "arm64"]
-          filters:
-            tags:
-              only: /.*/
-          requires: [pre-integration]
+      # - aws-ecr/build-and-push-image:
+      #     name: integration-tests-skip-when-tags-exist-populate-image-<<matrix.executor>>
+      #     attach-workspace: true
+      #     role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     region: "us-west-2"
+      #     assume-web-identity: true
+      #     profile-name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     workspace-root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
+      #     create-repo: true
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra-build-args: --compress
+      #     skip-when-tags-exist: true
+      #     matrix:
+      #       parameters:
+      #         executor: ["amd64", "arm64"]
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #     requires: [pre-integration]
 
-      - aws-ecr/build-and-push-image:
-          name: integration-tests-skip-when-tags-exist-<<matrix.executor>>
-          attach-workspace: true
-          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          region: "us-west-2"
-          assume-web-identity: true
-          profile-name: "OIDC-User"
-          context: [CPE-OIDC]
-          workspace-root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra-build-args: --compress
-          skip-when-tags-exist: true
-          aws-cli-version: 2.4.10
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: |
-                  aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>> --force
-          matrix:
-            parameters:
-              executor: ["amd64", "arm64"]
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - integration-tests-skip-when-tags-exist-populate-image-amd64
-            - integration-tests-skip-when-tags-exist-populate-image-arm64
+      # - aws-ecr/build-and-push-image:
+      #     name: integration-tests-skip-when-tags-exist-<<matrix.executor>>
+      #     attach-workspace: true
+      #     role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     region: "us-west-2"
+      #     assume-web-identity: true
+      #     profile-name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     workspace-root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>>
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra-build-args: --compress
+      #     skip-when-tags-exist: true
+      #     aws-cli-version: 2.4.10
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: |
+      #             aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip-when-tags-exist-<<matrix.executor>> --force
+      #     matrix:
+      #       parameters:
+      #         executor: ["amd64", "arm64"]
+      #     filters:
+      #       tags:
+      #         only: /.*/
+      #     requires:
+      #       - integration-tests-skip-when-tags-exist-populate-image-amd64
+      #       - integration-tests-skip-when-tags-exist-populate-image-arm64
 
       - orb-tools/lint:
           filters:
@@ -217,12 +217,12 @@ workflows:
             - orb-tools/lint
             - orb-tools/review
             - orb-tools/pack
-            - integration-tests-default-profile
+            # - integration-tests-default-profile
             - integration-tests-pubic-registry
-            - integration-tests-skip-when-tags-exist-amd64
-            - integration-tests-skip-when-tags-exist-arm64
-            - integration-tests-named-profile
-            - integration-tests-tag-existing-image
+            # - integration-tests-skip-when-tags-exist-amd64
+            # - integration-tests-skip-when-tags-exist-arm64
+            # - integration-tests-named-profile
+            # - integration-tests-tag-existing-image
           github-token: GHI_TOKEN
           context: orb-publisher
           filters:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -91,7 +91,7 @@ workflows:
           extra-build-args: "--compress"
           executor: amd64
           public-registry: true
-          platform: linux/arm64
+          platform: linux/arm64,linux/amd64
           # remote-docker-layer-caching: true
           # setup-remote-docker: true
           # post-steps:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -97,7 +97,7 @@ workflows:
             - run:
                 name: "Delete repository"
                 command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry --force
-          platform: linux/amd64,linux/arm64
+          platform: linux/arm64
           filters:
             tags:
               only: /.*/

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -91,7 +91,7 @@ workflows:
           extra-build-args: "--compress"
           executor: amd64
           public-registry: true
-          docker_layer_caching: true
+          remote-docker-layer-caching: true
           setup-remote-docker: true
           post-steps:
             - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -236,7 +236,7 @@ executors:
   amd64:
     machine:
       image: ubuntu-2204:2022.07.1
-      docker_layer_caching: <<parameters.remote-docker-layer-caching>>
+      docker_layer_caching: <<pipeline.parameters.remote-docker-layer-caching>>
     resource_class: medium
   arm64:
     machine:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -88,9 +88,10 @@ workflows:
           tag: integration,myECRRepoTag
           dockerfile: sample/Dockerfile
           path: workspace
-          extra-build-args: --compress
+          extra-build-args: "--compress"
           executor: amd64
           public-registry: true
+          docker_layer_caching: true
           post-steps:
             - run:
                 name: "Delete repository"
@@ -234,7 +235,10 @@ executors:
   amd64:
     machine:
       image: ubuntu-2204:2022.07.1
+    resource_class: medium
+    docker_layer_caching: <<pipeline.parameters.remote-docker-layer-caching>>
   arm64:
     machine:
       image: ubuntu-2204:2022.07.1
     resource_class: arm.medium
+    docker_layer_caching: <<pipeline.parameters.remote-docker-layer-caching>>

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -89,7 +89,7 @@ workflows:
           dockerfile: sample/Dockerfile
           path: workspace
           extra-build-args: "--compress"
-          executor: arm64
+          executor: amd64
           public-registry: true
           platform: linux/arm64
           # remote-docker-layer-caching: true

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -91,7 +91,7 @@ workflows:
           extra-build-args: "--compress"
           executor: amd64
           public-registry: true
-          remote-docker-layer-caching: true
+          # remote-docker-layer-caching: true
           # setup-remote-docker: true
           post-steps:
             - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -94,7 +94,7 @@ workflows:
           post-steps:
             - run:
                 name: "Delete repository"
-                command: aws ecr-public delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry --force
+                command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry --force
           platform: linux/amd64,linux/arm64
           filters:
             tags:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -236,7 +236,7 @@ executors:
   amd64:
     machine:
       image: ubuntu-2204:2022.07.1
-      docker_layer_caching: <<pipeline.parameters.remote-docker-layer-caching>>
+      docker_layer_caching: true
     resource_class: medium
   arm64:
     machine:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -236,9 +236,9 @@ executors:
     machine:
       image: ubuntu-2204:2022.07.1
     resource_class: medium
-    docker_layer_caching: <<pipeline.parameters.remote-docker-layer-caching>>
+    docker_layer_caching: <<parameters.remote-docker-layer-caching>>
   arm64:
     machine:
       image: ubuntu-2204:2022.07.1
     resource_class: arm.medium
-    docker_layer_caching: <<pipeline.parameters.remote-docker-layer-caching>>
+    docker_layer_caching: <<parameters.remote-docker-layer-caching>>

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -78,7 +78,7 @@ workflows:
           pre-steps:
             - run:
                 name: "Export env_var"
-                command: echo 'export VAR="--compress"' >> "$BASH_ENV"
+                command: echo 'export NPM_TOKEN="00000000-0000-0000-0000-000000000000"' >> "$BASH_ENV"
           name: integration-tests-pubic-registry
           attach-workspace: true
           workspace-root: workspace
@@ -92,7 +92,7 @@ workflows:
           tag: integration,myECRRepoTag
           dockerfile: Dockerfile
           path: ./sample
-          extra-build-args: '${VAR}'
+          extra-build-args: '--build-arg NPM_TOKEN=${NPM_TOKEN}'
           executor: amd64
           public-registry: true
           platform: linux/arm64

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -92,6 +92,7 @@ workflows:
           executor: amd64
           public-registry: true
           docker_layer_caching: true
+          setup-remote-docker: true
           post-steps:
             - run:
                 name: "Delete repository"
@@ -236,9 +237,7 @@ executors:
     machine:
       image: ubuntu-2204:2022.07.1
     resource_class: medium
-    docker_layer_caching: true
   arm64:
     machine:
       image: ubuntu-2204:2022.07.1
     resource_class: arm.medium
-    docker_layer_caching: true

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -94,10 +94,10 @@ workflows:
           platform: linux/arm64,linux/amd64
           # remote-docker-layer-caching: true
           # setup-remote-docker: true
-          # post-steps:
-          #   - run:
-          #       name: "Delete repository"
-          #       command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registrys --force
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registrys --force
           filters:
             tags:
               only: /.*/

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -97,7 +97,7 @@ workflows:
             - run:
                 name: "Delete repository"
                 command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry --force
-          platform: linux/arm64
+          platform: linux/amd64
           filters:
             tags:
               only: /.*/

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -236,9 +236,9 @@ executors:
     machine:
       image: ubuntu-2204:2022.07.1
     resource_class: medium
-    # docker_layer_caching: <<parameters.remote-docker-layer-caching>>
+    docker_layer_caching: true
   arm64:
     machine:
       image: ubuntu-2204:2022.07.1
     resource_class: arm.medium
-    # docker_layer_caching: <<parameters.remote-docker-layer-caching>>
+    docker_layer_caching: true

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -290,6 +290,7 @@ steps:
             public-registry: <<parameters.public-registry>>
             push-image: <<parameters.push-image>>
             public-registry-alias: <<parameters.public-registry-alias>>
+            remote-docker-layer-caching: <<parameters.remote-docker-layer-caching>>
 
   - unless:
       condition:

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -85,6 +85,13 @@ parameters:
     description: |
       The path to the .json file containing the lifecycle policy to be applied to a specified repository in AWS ECR.
 
+  remote-docker-layer-caching:
+    default: false
+    description: >
+      Enable Docker layer caching if using remote Docker engine. Defaults to
+      false.
+    type: boolean
+
 steps:
   - run:
       name: Build Docker Image with buildx
@@ -104,4 +111,13 @@ steps:
         ORB_VAL_LIFECYCLE_POLICY_PATH: <<parameters.lifecycle-policy-path>>
         ORB_EVAL_PUBLIC_REGISTRY_ALIAS: <<parameters.public-registry-alias>>
       command: <<include(scripts/docker-buildx.sh)>>
+      no_output_timeout: <<parameters.no-output-timeout>>
+  - run:
+      name: Clean up multi-architecture image build artifacts
+      environment:
+      when:
+        condition:
+          and:
+            - equal: [ true, <<parameters.remote-docker-layer-caching>> ]
+      command: <<include(scripts/docker-buildx-cleanup.sh)>>
       no_output_timeout: <<parameters.no-output-timeout>>

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -82,19 +82,18 @@ parameters:
   lifecycle-policy-path:
     type: string
     default: ""
-    description: |
+    description: >
       The path to the .json file containing the lifecycle policy to be applied to a specified repository in AWS ECR.
 
   remote-docker-layer-caching:
     default: false
     description: >
-      Enable Docker layer caching if using remote Docker engine. Defaults to
-      false.
+      Enable Docker layer caching if using remote Docker engine. Defaults to false.
     type: boolean
 
 steps:
   - run:
-      name: Build Docker Image with buildx
+      name: Build Docker Image with docker buildx
       environment:
         ORB_EVAL_TAG: << parameters.tag >>
         ORB_VAL_SKIP_WHEN_TAGS_EXIST: <<parameters.skip-when-tags-exist>>
@@ -110,14 +109,15 @@ steps:
         ORB_VAL_PUSH_IMAGE: <<parameters.push-image>>
         ORB_VAL_LIFECYCLE_POLICY_PATH: <<parameters.lifecycle-policy-path>>
         ORB_EVAL_PUBLIC_REGISTRY_ALIAS: <<parameters.public-registry-alias>>
+        ORB_VAL_REMOTE_DOCKER_LAYER_CACHING: <<parameters.remote-docker-layer-caching>
       command: <<include(scripts/docker-buildx.sh)>>
-      no_output_timeout: <<parameters.no-output-timeout>>
-  - run:
-      name: Clean up multi-architecture image build artifacts
-      environment:
-      when:
-        condition:
-          and:
-            - equal: [ true, <<parameters.remote-docker-layer-caching>> ]
-      command: <<include(scripts/docker-buildx-cleanup.sh)>>
-      no_output_timeout: <<parameters.no-output-timeout>>
+  #     no_output_timeout: <<parameters.no-output-timeout>>
+  # - run:
+  #     name: Clean up multi-architecture image build artifacts
+  #     environment:
+  #     when:
+  #       condition:
+  #         and:
+  #           - equal: [ true, <<parameters.remote-docker-layer-caching>> ]
+  #     command: <<include(scripts/docker-buildx-cleanup.sh)>>
+  #     no_output_timeout: <<parameters.no-output-timeout>>

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -109,7 +109,7 @@ steps:
         ORB_VAL_PUSH_IMAGE: <<parameters.push-image>>
         ORB_VAL_LIFECYCLE_POLICY_PATH: <<parameters.lifecycle-policy-path>>
         ORB_EVAL_PUBLIC_REGISTRY_ALIAS: <<parameters.public-registry-alias>>
-        ORB_VAL_REMOTE_DOCKER_LAYER_CACHING: <<parameters.remote-docker-layer-caching>
+        ORB_VAL_REMOTE_DOCKER_LAYER_CACHING: <<parameters.remote-docker-layer-caching>>
       command: <<include(scripts/docker-buildx.sh)>>
   #     no_output_timeout: <<parameters.no-output-timeout>>
   # - run:

--- a/src/examples/multi-arch-build.yml
+++ b/src/examples/multi-arch-build.yml
@@ -1,0 +1,82 @@
+description: Log into AWS, build multi-architecture image and push to ECR
+
+usage:
+  version: 2.1
+
+  orbs:
+    aws-ecr: circleci/aws-ecr@x.y
+
+  workflows:
+    build_and_push_image:
+      jobs:
+        # build and push image to ECR
+        - aws-ecr/build-and-push-image:
+            # Select executor defined above
+            executor: aws-ecr/default
+
+            # name of your ECR repository
+            repo: myECRRepository
+
+            # set this to true to create the repository if it does not already exist, defaults to "false"
+            create-repo: true
+
+            # required if any necessary secrets are stored via Contexts
+            context: myContext
+
+            # AWS profile name, defaults to "default"
+            profile-name: myProfileName
+
+            # name of env var storing your AWS Access Key ID, defaults to AWS_ACCESS_KEY_ID
+            aws-access-key-id: ACCESS_KEY_ID_ENV_VAR_NAME
+
+            # name of env var storing your AWS Secret Access Key, defaults to AWS_SECRET_ACCESS_KEY
+            aws-secret-access-key: SECRET_ACCESS_KEY_ENV_VAR_NAME
+
+            # Name of new profile associated with role arn.
+            new-profile-name: newProfileName
+
+            # Source profile containing credentials to assume the role with role-arn.
+            source-profile: sourceProfileName
+
+            # Role ARN that new profile should take
+            role-arn: arn:aws:iam::123456789012:role/testing
+
+            #Your AWS region
+            region: AWS_REGION
+
+            # name of env var storing your ECR Registry ID
+            registry-id: AWS_ECR_REGISTRY_ID
+
+            # ECR image tags (comma separated string), defaults to "latest"
+            tag: latest,myECRRepoTag
+
+            # name of Dockerfile to use, defaults to "Dockerfile"
+            dockerfile: myDockerfile
+
+            # path to Dockerfile, defaults to . (working directory)
+            path: pathToMyDockerfile
+
+            # Select a specific version of the AWS v2 CLI. By default the latest version will be used.
+            aws-cli-version: latest
+
+            # Boolean value if pushing to public registry. Defaults to true.
+            public-registry: false
+
+            # Security scans repository on push.  Defaults to true.
+            repo-scan-on-push: true
+
+            # The amount of time to allow the docker build command to run before timing out, defaults to "10m"
+            no-output-timeout: 20m
+
+            # Extra docker buildx build arguments
+            extra-build-args: --compress
+
+            # Specify platform targets (comma separated string) for built docker image.
+            platform: linux/amd64,linux/arm64
+
+            # Push image to repository after building.  Defaults to true
+            push-image: true
+
+            # Set to true if you don't want to build the image if it already exists in the ECR repo, for example when
+            # you are tagging with the git commit hash. Specially useful for faster code reverts.
+            skip-when-tags-exist: false

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -5,7 +5,7 @@ parameters:
   image:
     type: string
     default: ubuntu-2004:202107-02
-  use-docker-layer-caching:
+  remote-docker-layer-caching:
     type: boolean
     default: false
   resource-class:

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -14,6 +14,6 @@ parameters:
 
 machine:
   image: <<parameters.image>>
-  docker_layer_caching: <<parameters.use-docker-layer-caching>>
+  docker_layer_caching: <<parameters.remote-docker-layer-caching>>
 
 resource_class: <<parameters.resource-class>>

--- a/src/scripts/docker-buildx-cleanup.sh
+++ b/src/scripts/docker-buildx-cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# to prevent filesystem corruption, clean up multi-arch binary format handlers from the host prior to
+# saving updated cache
+docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-*

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -6,9 +6,9 @@ ORB_EVAL_PATH=$(eval echo "${ORB_EVAL_PATH}")
 ORB_VAL_ACCOUNT_URL="${!ORB_ENV_REGISTRY_ID}.dkr.ecr.${ORB_EVAL_REGION}.amazonaws.com"
 ORB_EVAL_PUBLIC_REGISTRY_ALIAS=$(eval echo "${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}")
 ECR_COMMAND="ecr"
-DOCKER_CONTEXT=""
+DOCKER_CONTEXT="--context builder"
 number_of_tags_in_ecr=0
-docker_tag_args="--context builder"
+docker_tag_args=""
 
 if [ "${ORB_VAL_PUBLIC_REGISTRY}" == "1" ]; then
   ECR_COMMAND="ecr-public"

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -46,19 +46,24 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     set -- "$@" "${ORB_VAL_EXTRA_BUILD_ARGS}"
   fi
 
-  # if ! docker context ls | grep builder; then
-  #   # We need to skip the creation of the builder context if it's already present
-  #   # otherwise the command will fail when called more than once in the same job.
+  context_args=""
 
-  #   docker context create builder
-  #   docker run --privileged --rm tonistiigi/binfmt --install all
-  #   docker --context builder buildx create --use
-  # fi
+  if ! docker context ls | grep builder; then
+    # We need to skip the creation of the builder context if it's already present
+    # otherwise the command will fail when called more than once in the same job.
+
+    docker context create builder
+    docker run --privileged --rm tonistiigi/binfmt --install all
+    docker --context builder buildx create --use
+    context_args="--context builder"
+  fi
   # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
   # docker --context builder buildx build \
-    docker buildx build \
+    docker \
+    ${context_arg:+"$context_arg"} \
+    buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
-    ${docker_tag_args} \
+    ${docker_tag_args:+"$docker_tag_args"} \
     --platform "${ORB_VAL_PLATFORM}" \
     --progress plain \
     "$@" \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -65,14 +65,16 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
  
 # Switch the Buildx Context to the new Builder
 #  context_args="--context zstd builder"
-
+set -x
+# shellcheck disable=SC2068
     docker buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     $docker_tag_args \
     --platform "${ORB_VAL_PLATFORM}" \
     --progress plain \
-    "$@" \
+    $@ \
     "${ORB_EVAL_PATH}"
+set +x    
   # docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-*
     # if [ "${ORB_VAL_REMOTE_DOCKER_LAYER_CACHING}" == "1" ]; then
     #   # to prevent filesystem corruption, clean up multi-arch binary format handlers from the host prior to

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -6,6 +6,7 @@ ORB_EVAL_PATH=$(eval echo "${ORB_EVAL_PATH}")
 ORB_VAL_ACCOUNT_URL="${!ORB_ENV_REGISTRY_ID}.dkr.ecr.${ORB_EVAL_REGION}.amazonaws.com"
 ORB_EVAL_PUBLIC_REGISTRY_ALIAS=$(eval echo "${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}")
 ECR_COMMAND="ecr"
+DOCKER_CONTEXT=""
 number_of_tags_in_ecr=0
 docker_tag_args=""
 
@@ -53,9 +54,9 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     docker run --privileged --rm tonistiigi/binfmt --install all
     docker --context builder buildx create --use
   fi
-
+  
   # docker --context builder buildx build \
-    docker buildx build \
+    docker "${DOCKER_CONTEXT}" buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     ${docker_tag_args} \
     --platform "${ORB_VAL_PLATFORM}" \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -55,13 +55,13 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     docker context create builder
     docker run --privileged --rm tonistiigi/binfmt --install all
     docker --context builder buildx create --use
-    # context_args=--context builder
+    context_args="--context builder"
   fi
   # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
-    # docker \
-    # buildx build \
-    # ${context_args:+"$context_args"} \
-  docker --context builder buildx build \
+  # docker \ --context builder buildx build \
+    docker \
+    buildx build \
+    ${context_args} \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     $docker_tag_args \
     --platform "${ORB_VAL_PLATFORM}" \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -48,22 +48,24 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
 
   # context_args=""
 
-  if ! docker context ls | grep builder; then
-    # We need to skip the creation of the builder context if it's already present
-    # otherwise the command will fail when called more than once in the same job.
+  # if ! docker context ls | grep builder; then
+  #   # We need to skip the creation of the builder context if it's already present
+  #   # otherwise the command will fail when called more than once in the same job.
+
+  #   docker context create builder
+  #   docker run --privileged --rm tonistiigi/binfmt --install all
+  #   docker --context builder buildx create --use
+  #   context_args="--context builder"
+  # fi
 
   docker buildx create \
-  --name builder \
+  --name zstd-builder \
   --driver docker-container \
   --driver-opt image=moby/buildkit:v0.10.3
-  
-  docker run --privileged --rm tonistiigi/binfmt --install all
-  docker --context builder buildx create --use
-    
-  context_args="--context builder"
-  fi
-  # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
-  # docker \ --context builder buildx build \
+ 
+# Switch the Buildx Context to the new Builder
+ context_args="--context zstd builder"
+
     docker ${context_args} buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     $docker_tag_args \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -60,8 +60,8 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
   # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
   # docker --context builder buildx build \
     docker \
-    $context_args \
     buildx build \
+    ${context_args:+"$context_args"} \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     ${docker_tag_args:+"$docker_tag_args"} \
     --platform "${ORB_VAL_PLATFORM}" \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -55,7 +55,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     docker context create builder
     docker run --privileged --rm tonistiigi/binfmt --install all
     docker --context builder buildx create --use
-    context_args=""
+    context_args="--context builder"
   fi
   # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
   # docker \ --context builder buildx build \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -63,7 +63,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     # ${context_args:+"$context_args"} \
   docker --context builder buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
-    ${docker_tag_args:+"$docker_tag_args"} \
+    $docker_tag_args \
     --platform "${ORB_VAL_PLATFORM}" \
     --progress plain \
     "$@" \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -10,6 +10,7 @@ ECR_COMMAND="ecr"
 # DOCKER_CONTEXT="--context builder"
 number_of_tags_in_ecr=0
 docker_tag_args=""
+context_args=""
 
 if [ "${ORB_VAL_PUBLIC_REGISTRY}" == "1" ]; then
   ECR_COMMAND="ecr-public"
@@ -84,7 +85,7 @@ set -x
     --progress plain \
     ${ORB_VAL_EXTRA_BUILD_ARGS:+$ORB_VAL_EXTRA_BUILD_ARGS} \
     "$@" \
-    "${ORB_EVAL_BUILD_PATH}"
+    .
 set +x
 
   # docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-*

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -55,7 +55,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     docker context create builder
     docker run --privileged --rm tonistiigi/binfmt --install all
     docker --context builder buildx create --use
-    context_args="--context builder"
+    # context_args="--context builder"
   fi
   # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
     # docker \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -61,7 +61,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
   # docker \ --context builder buildx build \
     docker \
     buildx build \
-    ${context_args} \
+    $context_args \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     $docker_tag_args \
     --platform "${ORB_VAL_PLATFORM}" \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -58,15 +58,15 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
   #   context_args="--context builder"
   # fi
 
-  docker buildx create \
-  --name zstd-builder \
-  --driver docker-container \
-  --driver-opt image=moby/buildkit:v0.10.3
+  # docker buildx create \
+  # --name zstd-builder \
+  # --driver docker-container \
+  # --driver-opt image=moby/buildkit:v0.10.3
  
 # Switch the Buildx Context to the new Builder
- context_args="--context zstd builder"
+#  context_args="--context zstd builder"
 
-    docker ${context_args} buildx build \
+    docker buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     $docker_tag_args \
     --platform "${ORB_VAL_PLATFORM}" \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -53,15 +53,15 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     set -- "$@" ${ORB_VAL_EXTRA_BUILD_ARGS}
   fi
 
-  if [ "${ORB_VAL_PUBLIC_REGISTRY}" == "1" ]; then
-    docker buildx build \
-      -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
-      ${docker_tag_args} \
-      --platform "${ORB_VAL_PLATFORM}" \
-      --progress plain \
-      "$@" \
-      "${ORB_EVAL_PATH}"
-  else
+  # if [ "${ORB_VAL_PUBLIC_REGISTRY}" == "1" ]; then
+  #   docker buildx build \
+  #     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
+  #     ${docker_tag_args} \
+  #     --platform "${ORB_VAL_PLATFORM}" \
+  #     --progress plain \
+  #     "$@" \
+  #     "${ORB_EVAL_PATH}"
+  # else
 
     if ! docker context ls | grep builder; then
       # We need to skip the creation of the builder context if it's already present
@@ -79,5 +79,10 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
       --progress plain \
       "$@" \
       "${ORB_EVAL_PATH}"
+      if [ "${ORB_VAL_REMOTE_DOCKER_LAYER_CACHING}" == "1" ]; then
+        # to prevent filesystem corruption, clean up multi-arch binary format handlers from the host prior to
+        # saving updated cache
+        docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-*
+      fi 
   fi
-fi
+# fi

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -60,7 +60,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
   # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
   # docker --context builder buildx build \
     docker \
-    ${context_args:+"$context_args"} \
+    $context_args \
     buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     ${docker_tag_args:+"$docker_tag_args"} \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -9,14 +9,14 @@ ECR_COMMAND="ecr"
 number_of_tags_in_ecr=0
 docker_tag_args=""
 
-IFS="," read -ra PLATFORMS <<<"${ORB_VAL_PLATFORM}"
-arch_count=${#PLATFORMS[@]}
+# IFS="," read -ra PLATFORMS <<<"${ORB_VAL_PLATFORM}"
+# arch_count=${#PLATFORMS[@]}
 
 if [ "${ORB_VAL_PUBLIC_REGISTRY}" == "1" ]; then
-  if [ "$arch_count" -gt 1 ]; then
-    echo "AWS ECR does not support multiple platforms for public registries. Please specify only one platform and try again"
-    exit 1
-  fi
+  # if [ "$arch_count" -gt 1 ]; then
+  #   echo "AWS ECR does not support multiple platforms for public registries. Please specify only one platform and try again"
+  #   exit 1
+  # fi
 
   ECR_COMMAND="ecr-public"
   ORB_VAL_ACCOUNT_URL="public.ecr.aws/${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}"

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -54,7 +54,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     docker run --privileged --rm tonistiigi/binfmt --install all
     docker --context builder buildx create --use
   fi
-  DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
+  # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
   #  docker "${DOCKER_CONTEXT}" buildx build \
     # "${DOCKER_COMMAND}" \
   docker --context builder buildx build \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -66,15 +66,26 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
 # Switch the Buildx Context to the new Builder
 #  context_args="--context zstd builder"
 set -x
-# shellcheck disable=SC2068
-    docker buildx build \
+# # shellcheck disable=SC2068
+#     docker buildx build \
+#     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
+#     $docker_tag_args \
+#     --platform "${ORB_VAL_PLATFORM}" \
+#     --progress plain \
+#     $@ \
+#     "${ORB_EVAL_PATH}"
+  docker \
+    ${context_args:+$context_args} \
+    buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
-    $docker_tag_args \
+    ${docker_tag_args:+$docker_tag_args} \
     --platform "${ORB_VAL_PLATFORM}" \
     --progress plain \
-    $@ \
-    "${ORB_EVAL_PATH}"
-set +x    
+    ${ORB_VAL_EXTRA_BUILD_ARGS:+$ORB_VAL_EXTRA_BUILD_ARGS} \
+    "$@" \
+    "${ORB_EVAL_BUILD_PATH}"
+set +x
+
   # docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-*
     # if [ "${ORB_VAL_REMOTE_DOCKER_LAYER_CACHING}" == "1" ]; then
     #   # to prevent filesystem corruption, clean up multi-arch binary format handlers from the host prior to

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -61,9 +61,10 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     --progress plain \
     "$@" \
     "${ORB_EVAL_PATH}"
-    if [ "${ORB_VAL_REMOTE_DOCKER_LAYER_CACHING}" == "1" ]; then
-      # to prevent filesystem corruption, clean up multi-arch binary format handlers from the host prior to
-      # saving updated cache
-      docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-*
-    fi 
+  docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-*
+    # if [ "${ORB_VAL_REMOTE_DOCKER_LAYER_CACHING}" == "1" ]; then
+    #   # to prevent filesystem corruption, clean up multi-arch binary format handlers from the host prior to
+    #   # saving updated cache
+    #   docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-*
+    # fi 
 fi

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -58,10 +58,10 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     context_args="--context builder"
   fi
   # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
-  # docker --context builder buildx build \
-    docker \
-    buildx build \
-    ${context_args:+"$context_args"} \
+    # docker \
+    # buildx build \
+    # ${context_args:+"$context_args"} \
+  docker --context builder buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     ${docker_tag_args:+"$docker_tag_args"} \
     --platform "${ORB_VAL_PLATFORM}" \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -60,7 +60,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
   # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
   # docker --context builder buildx build \
     docker \
-    ${context_arg:+"$context_arg"} \
+    ${context_args:+"$context_args"} \
     buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     ${docker_tag_args:+"$docker_tag_args"} \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -55,9 +55,8 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     docker --context builder buildx create --use
   fi
   # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
-  #  docker "${DOCKER_CONTEXT}" buildx build \
-    # "${DOCKER_COMMAND}" \
-  docker --context builder buildx build \
+  # docker --context builder buildx build \
+    docker buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     ${docker_tag_args} \
     --platform "${ORB_VAL_PLATFORM}" \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -55,9 +55,9 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     docker --context builder buildx create --use
   fi
   DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
-  # docker --context builder buildx build \
   #  docker "${DOCKER_CONTEXT}" buildx build \
-    "${DOCKER_COMMAND}" \
+    # "${DOCKER_COMMAND}" \
+  docker --context builder buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     ${docker_tag_args} \
     --platform "${ORB_VAL_PLATFORM}" \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -60,7 +60,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
   # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
   # docker \ --context builder buildx build \
     docker \
-    ${context_args:+"-c$context_args"} \
+    ${context_args} \
     buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     $docker_tag_args \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -54,14 +54,15 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     docker --context builder buildx create --use
   fi
 
-  docker --context builder buildx build \
+  # docker --context builder buildx build \
+    docker buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     ${docker_tag_args} \
     --platform "${ORB_VAL_PLATFORM}" \
     --progress plain \
     "$@" \
     "${ORB_EVAL_PATH}"
-  docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-*
+  # docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-*
     # if [ "${ORB_VAL_REMOTE_DOCKER_LAYER_CACHING}" == "1" ]; then
     #   # to prevent filesystem corruption, clean up multi-arch binary format handlers from the host prior to
     #   # saving updated cache

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -50,7 +50,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
 
   if [ -n "$ORB_VAL_EXTRA_BUILD_ARGS" ]; then
     ORB_VAL_EXTRA_BUILD_ARGS=$(eval echo "${ORB_VAL_EXTRA_BUILD_ARGS}")
-    set -- "$@" ${ORB_VAL_EXTRA_BUILD_ARGS}
+    set -- "$@" "${ORB_VAL_EXTRA_BUILD_ARGS}"
   fi
 
   # if [ "${ORB_VAL_PUBLIC_REGISTRY}" == "1" ]; then

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -54,9 +54,10 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     docker run --privileged --rm tonistiigi/binfmt --install all
     docker --context builder buildx create --use
   fi
-  
+  DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
   # docker --context builder buildx build \
-    docker "${DOCKER_CONTEXT}" buildx build \
+  #  docker "${DOCKER_CONTEXT}" buildx build \
+    "${DOCKER_COMMAND}" \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     ${docker_tag_args} \
     --platform "${ORB_VAL_PLATFORM}" \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -60,7 +60,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
   # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
   # docker \ --context builder buildx build \
     docker \
-    ${context_args} \
+    ${context_args:+"-c$context_args"} \
     buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     $docker_tag_args \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -60,7 +60,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
   # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
   # docker \ --context builder buildx build \
     docker \
-    $context_args \
+    ${context_args} \
     buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     $docker_tag_args \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -8,7 +8,7 @@ ORB_EVAL_PUBLIC_REGISTRY_ALIAS=$(eval echo "${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}")
 ECR_COMMAND="ecr"
 DOCKER_CONTEXT=""
 number_of_tags_in_ecr=0
-docker_tag_args=""
+docker_tag_args="--context builder"
 
 if [ "${ORB_VAL_PUBLIC_REGISTRY}" == "1" ]; then
   ECR_COMMAND="ecr-public"

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -52,10 +52,15 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     # We need to skip the creation of the builder context if it's already present
     # otherwise the command will fail when called more than once in the same job.
 
-    docker context create builder
-    docker run --privileged --rm tonistiigi/binfmt --install all
-    docker --context builder buildx create --use
-    context_args="--context builder"
+  docker buildx create \
+  --name builder \
+  --driver docker-container \
+  --driver-opt image=moby/buildkit:v0.10.3
+  
+  docker run --privileged --rm tonistiigi/binfmt --install all
+  docker --context builder buildx create --use
+    
+  context_args="--context builder"
   fi
   # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
   # docker \ --context builder buildx build \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -46,14 +46,14 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     set -- "$@" "${ORB_VAL_EXTRA_BUILD_ARGS}"
   fi
 
-  if ! docker context ls | grep builder; then
-    # We need to skip the creation of the builder context if it's already present
-    # otherwise the command will fail when called more than once in the same job.
+  # if ! docker context ls | grep builder; then
+  #   # We need to skip the creation of the builder context if it's already present
+  #   # otherwise the command will fail when called more than once in the same job.
 
-    docker context create builder
-    docker run --privileged --rm tonistiigi/binfmt --install all
-    docker --context builder buildx create --use
-  fi
+  #   docker context create builder
+  #   docker run --privileged --rm tonistiigi/binfmt --install all
+  #   docker --context builder buildx create --use
+  # fi
   # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
   # docker --context builder buildx build \
     docker buildx build \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -59,9 +59,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
   fi
   # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
   # docker \ --context builder buildx build \
-    docker \
-    ${context_args} \
-    buildx build \
+    docker ${context_args} buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     $docker_tag_args \
     --platform "${ORB_VAL_PLATFORM}" \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -55,7 +55,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     docker context create builder
     docker run --privileged --rm tonistiigi/binfmt --install all
     docker --context builder buildx create --use
-    context_args="--context builder"
+    context_args=""
   fi
   # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
   # docker \ --context builder buildx build \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -60,8 +60,8 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
   # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
   # docker \ --context builder buildx build \
     docker \
-    buildx build \
     $context_args \
+    buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
     $docker_tag_args \
     --platform "${ORB_VAL_PLATFORM}" \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -46,7 +46,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     set -- "$@" "${ORB_VAL_EXTRA_BUILD_ARGS}"
   fi
 
-  context_args=""
+  # context_args=""
 
   if ! docker context ls | grep builder; then
     # We need to skip the creation of the builder context if it's already present
@@ -55,7 +55,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     docker context create builder
     docker run --privileged --rm tonistiigi/binfmt --install all
     docker --context builder buildx create --use
-    # context_args="--context builder"
+    # context_args=--context builder
   fi
   # DOCKER_COMMAND=$(eval echo "docker ${DOCKER_CONTEXT} buildx build")
     # docker \

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -5,6 +5,7 @@ ORB_EVAL_TAG=$(eval echo "${ORB_EVAL_TAG}")
 ORB_EVAL_PATH=$(eval echo "${ORB_EVAL_PATH}")
 ORB_VAL_ACCOUNT_URL="${!ORB_ENV_REGISTRY_ID}.dkr.ecr.${ORB_EVAL_REGION}.amazonaws.com"
 ORB_EVAL_PUBLIC_REGISTRY_ALIAS=$(eval echo "${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}")
+ORB_VAL_EXTRA_BUILD_ARGS=$(eval echo "${ORB_VAL_EXTRA_BUILD_ARGS}")
 ECR_COMMAND="ecr"
 # DOCKER_CONTEXT="--context builder"
 number_of_tags_in_ecr=0
@@ -41,10 +42,10 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     set -- "$@" --load
   fi
 
-  if [ -n "$ORB_VAL_EXTRA_BUILD_ARGS" ]; then
-    ORB_VAL_EXTRA_BUILD_ARGS=$(eval echo "${ORB_VAL_EXTRA_BUILD_ARGS}")
-    set -- "$@" "${ORB_VAL_EXTRA_BUILD_ARGS}"
-  fi
+  # if [ -n "$ORB_VAL_EXTRA_BUILD_ARGS" ]; then
+  #   ORB_VAL_EXTRA_BUILD_ARGS=$(eval echo "${ORB_VAL_EXTRA_BUILD_ARGS}")
+  #   set -- "$@" "${ORB_VAL_EXTRA_BUILD_ARGS}"
+  # fi
 
   # context_args=""
 

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -6,7 +6,7 @@ ORB_EVAL_PATH=$(eval echo "${ORB_EVAL_PATH}")
 ORB_VAL_ACCOUNT_URL="${!ORB_ENV_REGISTRY_ID}.dkr.ecr.${ORB_EVAL_REGION}.amazonaws.com"
 ORB_EVAL_PUBLIC_REGISTRY_ALIAS=$(eval echo "${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}")
 ECR_COMMAND="ecr"
-DOCKER_CONTEXT="--context builder"
+# DOCKER_CONTEXT="--context builder"
 number_of_tags_in_ecr=0
 docker_tag_args=""
 


### PR DESCRIPTION

Currently, when remote docker is used with the latest iteration of Docker Layer Caching (DLC), a multi-architecture build can leave filesystem entries behind that cause corruption upon saving the layer cache. Invoking docker run --privileged --rm tonistiigi/binfmt --install all as part of the buildx context creation registers various qemu-based binary format hooks on the host system. If these are not cleaned up prior to saving the /var/lib/docker layer cache, the resulting ext4 filesystem is considered corrupt due to missing links.

The fix proposed here is to conditionally (i.e. if remote-docker-layer-caching is provided in the parameters) invoke docker run --privileged --rm tonistiigi/binfmt --uninstall qemu-* to remove the qemu binary format handlers prior to the end of the workflow to preserve a valid state of the filesystem for caching.

