### PR TITLE
feat: push multi-architecture images to public registries

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -95,7 +95,7 @@ workflows:
             - run:
                 name: "Delete repository"
                 command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry --force
-          platform: linux/amd64
+          platform: linux/amd64,linux/arm64
           filters:
             tags:
               only: /.*/

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -9,15 +9,7 @@ ECR_COMMAND="ecr"
 number_of_tags_in_ecr=0
 docker_tag_args=""
 
-IFS="," read -ra PLATFORMS <<<"${ORB_VAL_PLATFORM}"
-arch_count=${#PLATFORMS[@]}
-
 if [ "${ORB_VAL_PUBLIC_REGISTRY}" == "1" ]; then
-  if [ "$arch_count" -gt 1 ]; then
-    echo "AWS ECR does not support multiple platforms for public registries. Please specify only one platform and try again"
-    exit 1
-  fi
-
   ECR_COMMAND="ecr-public"
   ORB_VAL_ACCOUNT_URL="public.ecr.aws/${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}"
 fi
@@ -50,34 +42,23 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
 
   if [ -n "$ORB_VAL_EXTRA_BUILD_ARGS" ]; then
     ORB_VAL_EXTRA_BUILD_ARGS=$(eval echo "${ORB_VAL_EXTRA_BUILD_ARGS}")
-    set -- "$@" ${ORB_VAL_EXTRA_BUILD_ARGS}
+    set -- "$@" "${ORB_VAL_EXTRA_BUILD_ARGS}"
   fi
 
-  if [ "${ORB_VAL_PUBLIC_REGISTRY}" == "1" ]; then
-    docker buildx build \
-      -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
-      ${docker_tag_args} \
-      --platform "${ORB_VAL_PLATFORM}" \
-      --progress plain \
-      "$@" \
-      "${ORB_EVAL_PATH}"
-  else
+  if ! docker context ls | grep builder; then
+    # We need to skip the creation of the builder context if it's already present
+    # otherwise the command will fail when called more than once in the same job.
 
-    if ! docker context ls | grep builder; then
-      # We need to skip the creation of the builder context if it's already present
-      # otherwise the command will fail when called more than once in the same job.
-
-      docker context create builder
-      docker run --privileged --rm tonistiigi/binfmt --install all
-      docker --context builder buildx create --use
-    fi
-
-    docker --context builder buildx build \
-      -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
-      ${docker_tag_args} \
-      --platform "${ORB_VAL_PLATFORM}" \
-      --progress plain \
-      "$@" \
-      "${ORB_EVAL_PATH}"
+    docker context create builder
+    docker run --privileged --rm tonistiigi/binfmt --install all
+    docker --context builder buildx create --use
   fi
+
+  docker --context builder buildx build \
+    -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
+    "${docker_tag_args}" \
+    --platform "${ORB_VAL_PLATFORM}" \
+    --progress plain \
+    "$@" \
+    "${ORB_EVAL_PATH}"
 fi

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -42,7 +42,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
 
   if [ -n "$ORB_VAL_EXTRA_BUILD_ARGS" ]; then
     ORB_VAL_EXTRA_BUILD_ARGS=$(eval echo "${ORB_VAL_EXTRA_BUILD_ARGS}")
-    set -- "$@" "${ORB_VAL_EXTRA_BUILD_ARGS}"
+    set -- "$@" ${ORB_VAL_EXTRA_BUILD_ARGS}
   fi
 
   if ! docker context ls | grep builder; then

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -42,7 +42,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
 
   if [ -n "$ORB_VAL_EXTRA_BUILD_ARGS" ]; then
     ORB_VAL_EXTRA_BUILD_ARGS=$(eval echo "${ORB_VAL_EXTRA_BUILD_ARGS}")
-    set -- "$@" ${ORB_VAL_EXTRA_BUILD_ARGS}
+    set -- "$@" "${ORB_VAL_EXTRA_BUILD_ARGS}"
   fi
 
   if ! docker context ls | grep builder; then
@@ -56,7 +56,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
 
   docker --context builder buildx build \
     -f "${ORB_EVAL_PATH}"/"${ORB_VAL_DOCKERFILE}" \
-    "${docker_tag_args}" \
+    ${docker_tag_args} \
     --platform "${ORB_VAL_PLATFORM}" \
     --progress plain \
     "$@" \


### PR DESCRIPTION
This `PR` adds the capability to push multi-architecture images for public registries n `aws ecr`.  There has been a previous fix in PR #235 that changes the `uri` of the public registry schema to use an assigned `registry-alias`. This enabled pushing multi-architecture images to public registries using the `docker buildx build` command. 