### PR TITLE
feat: add validation for registry id

### DIFF
--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -9,6 +9,11 @@ ECR_COMMAND="ecr"
 number_of_tags_in_ecr=0
 docker_tag_args=""
 
+if [ -z "${!ORB_ENV_REGISTRY_ID}" ]; then
+  echo "The registry ID is not found. Please add the registry ID as an environment variable in CicleCI before continuing."
+  exit 1
+fi
+
 if [ "${ORB_VAL_PUBLIC_REGISTRY}" == "1" ]; then
   ECR_COMMAND="ecr-public"
   ORB_VAL_ACCOUNT_URL="public.ecr.aws/${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}"

--- a/src/scripts/ecr-login.sh
+++ b/src/scripts/ecr-login.sh
@@ -3,6 +3,11 @@ ORB_EVAL_REGION=$(eval echo "${ORB_EVAL_REGION}")
 ORB_VAL_ACCOUNT_URL="${!ORB_ENV_REGISTRY_ID}.dkr.ecr.${ORB_EVAL_REGION}.amazonaws.com"
 ECR_COMMAND="ecr"
 
+if [ -z "${!ORB_ENV_REGISTRY_ID}" ]; then
+  echo "The registry ID is not found. Please add the registry ID as an environment variable in CicleCI before continuing."
+  exit 1
+fi
+
 if [ "$ORB_VAL_PUBLIC_REGISTRY" == "1" ]; then
     ORB_EVAL_REGION="us-east-1"
     ORB_VAL_ACCOUNT_URL="public.ecr.aws"

--- a/src/scripts/push-image.sh
+++ b/src/scripts/push-image.sh
@@ -5,6 +5,11 @@ ORB_EVAL_REGION=$(eval echo "${ORB_EVAL_REGION}")
 ORB_VAL_ACCOUNT_URL="${!ORB_ENV_REGISTRY_ID}.dkr.ecr.${ORB_EVAL_REGION}.amazonaws.com"
 ORB_EVAL_PUBLIC_REGISTRY_ALIAS=$(eval echo "${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}")
 
+if [ -z "${!ORB_ENV_REGISTRY_ID}" ]; then
+  echo "The registry ID is not found. Please add the registry ID as an environment variable in CicleCI before continuing."
+  exit 1
+fi
+
 if [ "${ORB_VAL_PUBLIC_REGISTRY}" == "1" ]; then
   ORB_VAL_ACCOUNT_URL="public.ecr.aws/${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}"
 fi


### PR DESCRIPTION
This `PR` adds validation for the required `registry-id` parameter with an `env_var` type. 

If a user does not add one in CircleCI, the job fails with an `exit 1`