### PR TITLE
fix: evaluated extra build arg parameter

### DIFF
--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -92,7 +92,7 @@ steps:
         ORB_EVAL_TAG: << parameters.tag >>
         ORB_VAL_SKIP_WHEN_TAGS_EXIST: <<parameters.skip-when-tags-exist>>
         ORB_EVAL_REPO: << parameters.repo >>
-        ORB_VAL_EXTRA_BUILD_ARGS: <<parameters.extra-build-args>>
+        ORB_EVAL_EXTRA_BUILD_ARGS: <<parameters.extra-build-args>>
         ORB_EVAL_PATH: <<parameters.path>>
         ORB_VAL_DOCKERFILE: <<parameters.dockerfile>>
         ORB_VAL_PROFILE_NAME: <<parameters.profile-name>>

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -5,6 +5,7 @@ ORB_EVAL_TAG=$(eval echo "${ORB_EVAL_TAG}")
 ORB_EVAL_PATH=$(eval echo "${ORB_EVAL_PATH}")
 ORB_VAL_ACCOUNT_URL="${!ORB_ENV_REGISTRY_ID}.dkr.ecr.${ORB_EVAL_REGION}.amazonaws.com"
 ORB_EVAL_PUBLIC_REGISTRY_ALIAS=$(eval echo "${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}")
+ORB_EVAL_EXTRA_BUILD_ARGS=$(eval echo "${ORB_EVAL_EXTRA_BUILD_ARGS}")
 ECR_COMMAND="ecr"
 number_of_tags_in_ecr=0
 docker_tag_args=""
@@ -45,9 +46,9 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     set -- "$@" --load
   fi
 
-  if [ -n "$ORB_VAL_EXTRA_BUILD_ARGS" ]; then
-    ORB_VAL_EXTRA_BUILD_ARGS=$(eval echo "${ORB_VAL_EXTRA_BUILD_ARGS}")
-    set -- "$@" "${ORB_VAL_EXTRA_BUILD_ARGS}"
+  if [ -n "${ORB_EVAL_EXTRA_BUILD_ARGS}" ]; then
+    ORB_EVAL_EXTRA_BUILD_ARGS=$(eval echo "${ORB_EVAL_EXTRA_BUILD_ARGS}")
+    set -- "$@" "${ORB_EVAL_EXTRA_BUILD_ARGS}"
   fi
 
   if ! docker context ls | grep builder; then


### PR DESCRIPTION
This `PR` evaluates the `extra-build-args` parameter. Now users are able to use expressions containing sub shells like `--build-arg VERSION=$(cat version.txt)` will be properly evaluated.