### PR TITLE
feat: add build-path parameter

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -86,8 +86,8 @@ workflows:
           profile-name: "OIDC-User"
           context: [CPE-OIDC]
           tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
+          dockerfile: Dockerfile
+          path: ./sample
           extra-build-args: --compress
           executor: amd64
           public-registry: true

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -314,7 +314,7 @@ steps:
             region: <<parameters.region>>
             public-registry: <<parameters.public-registry>>
             push-image: <<parameters.push-image>>
-            lifecycle-policy-path: <<parameters.lifecycle-policy-path>>            
+            lifecycle-policy-path: <<parameters.lifecycle-policy-path>>
             public-registry-alias: <<parameters.public-registry-alias>>
             build-path: <<parameters.build-path>>
 

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -163,10 +163,14 @@ parameters:
   path:
     default: .
     description: >-
-      Path to the directory containing your Dockerfile and build context.
-      Defaults to . (working directory).
+      Path to the directory containing your Dockerfile. Defaults to . (working directory).
     type: string
 
+  build-path:
+    default: .
+    description: >-
+      Path to the directory containing your build context. Defaults to . (working directory).
+    type: string
   extra-build-args:
     default: ""
     description: >
@@ -310,7 +314,9 @@ steps:
             region: <<parameters.region>>
             public-registry: <<parameters.public-registry>>
             push-image: <<parameters.push-image>>
+            lifecycle-policy-path: <<parameters.lifecycle-policy-path>>            
             public-registry-alias: <<parameters.public-registry-alias>>
+            build-path: <<parameters.build-path>>
 
   - unless:
       condition:
@@ -334,3 +340,4 @@ steps:
             push-image: <<parameters.push-image>>
             lifecycle-policy-path: <<parameters.lifecycle-policy-path>>
             public-registry-alias: <<parameters.public-registry-alias>>
+            build-path: <<parameters.build-path>>

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -23,9 +23,16 @@ parameters:
     description: Name of dockerfile to use. Defaults to Dockerfile.
 
   path:
-    type: string
     default: .
-    description: Path to the directory containing your Dockerfile and build context. Defaults to . (working directory).
+    description: >-
+      Path to the directory containing your Dockerfile. Defaults to . (working directory).
+    type: string
+
+  build-path:
+    default: .
+    description: >-
+      Path to the directory containing your build context. Defaults to . (working directory).
+    type: string
 
   no-output-timeout:
     type: string
@@ -103,5 +110,6 @@ steps:
         ORB_VAL_PUSH_IMAGE: <<parameters.push-image>>
         ORB_VAL_LIFECYCLE_POLICY_PATH: <<parameters.lifecycle-policy-path>>
         ORB_EVAL_PUBLIC_REGISTRY_ALIAS: <<parameters.public-registry-alias>>
+        ORB_EVAL_BUILD_PATH: <<parameters.build-path>>
       command: <<include(scripts/docker-buildx.sh)>>
       no_output_timeout: <<parameters.no-output-timeout>>

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -6,6 +6,7 @@ ORB_EVAL_PATH=$(eval echo "${ORB_EVAL_PATH}")
 ORB_VAL_ACCOUNT_URL="${!ORB_ENV_REGISTRY_ID}.dkr.ecr.${ORB_EVAL_REGION}.amazonaws.com"
 ORB_EVAL_PUBLIC_REGISTRY_ALIAS=$(eval echo "${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}")
 ORB_EVAL_EXTRA_BUILD_ARGS=$(eval echo "${ORB_EVAL_EXTRA_BUILD_ARGS}")
+ORB_EVAL_BUILD_PATH=$(eval echo "${ORB_EVAL_BUILD_PATH}")
 ECR_COMMAND="ecr"
 number_of_tags_in_ecr=0
 
@@ -78,7 +79,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     --platform "${ORB_VAL_PLATFORM}" \
     --progress plain \
     "$@" \
-    "${ORB_EVAL_PATH}"
+    "${ORB_EVAL_BUILD_PATH}"
   set +x
   
 fi


### PR DESCRIPTION
This `PR` adds the `build-path` parameter to the `docker-build-and-push-image` command and job along with the `build-image` command. 

This enables users to specify the path of the build directory in the case that it differs from the path to the `Dockerfile`.

