### PR TITLE
fix: extra-build-args expansion

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -102,6 +102,10 @@ workflows:
           requires: [pre-integration]
 
       - aws-ecr/build-and-push-image:
+          pre-steps:
+            - run:
+                name: "Export NPM_TOKEN"
+                command: echo 'export NPM_TOKEN="00000000-0000-0000-0000-000000000000"' >> "$BASH_ENV"      
           name: integration-tests-named-profile
           attach-workspace: true
           role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
@@ -115,7 +119,7 @@ workflows:
           tag: integration,myECRRepoTag
           dockerfile: sample/Dockerfile
           path: workspace
-          extra-build-args: --compress
+          extra-build-args: '--build-arg NPM_TOKEN=${NPM_TOKEN}'
           set-repo-policy: true
           repo-policy-path: ./sample/repo-policy.json
           executor: amd64

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -49,12 +49,6 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     set -- "$@" --load
   fi
 
-  if [ -n "${ORB_EVAL_EXTRA_BUILD_ARGS}" ]; then
-    set -- "$@" "${ORB_EVAL_EXTRA_BUILD_ARGS}"
-  fi
-
-
-
   if [ "${number_of_platforms}" -gt 1 ]; then
     # In order to build multi-architecture images, a context with binfmt installed must be used. 
     # However, Docker Layer Caching with multi-architecture builds is not currently supported
@@ -79,6 +73,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     --platform "${ORB_VAL_PLATFORM}" \
     --progress plain \
     "$@" \
+    ${ORB_VAL_EXTRA_BUILD_ARGS:+$ORB_VAL_EXTRA_BUILD_ARGS} \
     "${ORB_EVAL_BUILD_PATH}"
   set +x
   

--- a/src/scripts/docker-buildx.sh
+++ b/src/scripts/docker-buildx.sh
@@ -73,7 +73,7 @@ if [ "${ORB_VAL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_VAL_SKIP_WHEN_TAGS_E
     --platform "${ORB_VAL_PLATFORM}" \
     --progress plain \
     "$@" \
-    ${ORB_VAL_EXTRA_BUILD_ARGS:+$ORB_VAL_EXTRA_BUILD_ARGS} \
+    ${ORB_EVAL_EXTRA_BUILD_ARGS:+$ORB_EVAL_EXTRA_BUILD_ARGS} \
     "${ORB_EVAL_BUILD_PATH}"
   set +x
   


### PR DESCRIPTION
This `PR` separates the expansion of the `extra-build-args` from the `$@` array and expands with `${ORB_EVAL_EXTRA_BUILD_ARGS:+$ORB_EVAL_EXTRA_BUILD_ARGS}` at runtime. 
