### PR TITLE
Update `image.default` to latest version that supports ARM

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -4,7 +4,7 @@ description: >
 parameters:
   image:
     type: string
-    default: ubuntu-2004:202107-02
+    default: ubuntu-2004:2022.04.1
   use-docker-layer-caching:
     type: boolean
     default: false


### PR DESCRIPTION
### Motivation, issues

Can't use `arm.medium` for the `resource_class`, because current default image is set to `202107-02` which doesn't have ARM support.

### Description

Update the default image to the latest one that has ARM support. More info: https://circleci.com/docs/using-arm/#images-with-arm-support