### PR TITLE
feat!/auth-step-parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  orb-tools: circleci/orb-tools@11.1
+  orb-tools: circleci/orb-tools@11.6
   shellcheck: circleci/shellcheck@3.1
 
 workflows:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,7 +1,13 @@
 version: 2.1
 orbs:
   aws-ecr: circleci/aws-ecr@dev:<<pipeline.git.revision>>
-  orb-tools: circleci/orb-tools@11.4
+  orb-tools: circleci/orb-tools@11.6
+  aws-cli: circleci/aws-cli@3.1
+
+filters: &filters
+  tags:
+    only: /.*/
+
 jobs:
   pre-integration-checkout-workspace-job:
     docker:
@@ -22,21 +28,17 @@ jobs:
         type: string
       target-tag:
         type: string
-      role-arn:
-        type: string
       region:
         type: string
       profile-name:
         type: string
-      assume-web-identity:
-        type: boolean
-        default: false
+      auth:
+        type: steps
     steps:
+      - steps: <<parameters.auth>>
       - aws-ecr/ecr-login:
           profile-name: <<parameters.profile-name>>
-          role-arn: <<parameters.role-arn>>
           region: <<parameters.region>>
-          assume-web-identity: <<parameters.assume-web-identity>>
       - aws-ecr/tag-image:
           repo: <<parameters.repo>>
           source-tag: <<parameters.source-tag>>
@@ -46,12 +48,13 @@ workflows:
     jobs:
       - pre-integration-checkout-workspace-job:
           name: pre-integration
-          filters:
-            tags:
-              only: /.*/
+          filters: *filters
 
       - aws-ecr/build-and-push-image:
           name: integration-tests-default-profile
+          auth:
+            - aws-cli/setup:
+                role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           attach-workspace: true
           workspace-root: workspace
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
@@ -62,27 +65,26 @@ workflows:
           path: workspace
           extra-build-args: --compress
           executor: amd64
-          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_ADMIN
           lifecycle-policy-path: ./sample/lifecycle-policy.json
           post-steps:
             - run:
                 name: "Delete repository"
                 command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile --force
           platform: linux/amd64,linux/arm64
-          filters:
-            tags:
-              only: /.*/
+          filters: *filters
           requires: [pre-integration]
 
       - aws-ecr/build-and-push-image:
           name: integration-tests-pubic-registry
+          auth:
+            - aws-cli/setup:
+                role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile-name: "OIDC-User"
           attach-workspace: true
           workspace-root: workspace
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry
           create-repo: true
-          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           region: "us-west-2"
-          assume-web-identity: true
           profile-name: "OIDC-User"
           context: [CPE-OIDC]
           tag: integration,myECRRepoTag
@@ -96,17 +98,17 @@ workflows:
                 name: "Delete repository"
                 command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public-registry --force
           platform: linux/amd64,linux/arm64
-          filters:
-            tags:
-              only: /.*/
+          filters: *filters
           requires: [pre-integration]
 
       - aws-ecr/build-and-push-image:
           name: integration-tests-named-profile
+          auth:
+            - aws-cli/setup:
+                role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile-name: "OIDC-User"
           attach-workspace: true
-          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           region: "us-west-2"
-          assume-web-identity: true
           profile-name: "OIDC-User"
           context: [CPE-OIDC]
           workspace-root: workspace
@@ -119,17 +121,17 @@ workflows:
           set-repo-policy: true
           repo-policy-path: ./sample/repo-policy.json
           executor: amd64
-          filters:
-            tags:
-              only: /.*/
+          filters: *filters
           requires: [pre-integration]
 
       - tag-ecr-image:
           name: integration-tests-tag-existing-image
+          auth:
+            - aws-cli/setup:
+                role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile-name: "OIDC-User"
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           region: "us-west-2"
-          assume-web-identity: true
           profile-name: "OIDC-User"
           context: [CPE-OIDC]
           source-tag: integration
@@ -138,18 +140,18 @@ workflows:
             - run:
                 name: "Delete repository"
                 command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile --force
-          filters:
-            tags:
-              only: /.*/
+          filters: *filters
           requires:
             - integration-tests-named-profile
 
       - aws-ecr/build-and-push-image:
           name: integration-tests-skip-when-tags-exist-populate-image-<<matrix.executor>>
+          auth:
+            - aws-cli/setup:
+                role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile-name: "OIDC-User"          
           attach-workspace: true
-          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           region: "us-west-2"
-          assume-web-identity: true
           profile-name: "OIDC-User"
           context: [CPE-OIDC]
           workspace-root: workspace
@@ -163,17 +165,17 @@ workflows:
           matrix:
             parameters:
               executor: ["amd64", "arm64"]
-          filters:
-            tags:
-              only: /.*/
+          filters: *filters
           requires: [pre-integration]
 
       - aws-ecr/build-and-push-image:
           name: integration-tests-skip-when-tags-exist-<<matrix.executor>>
+          auth:
+            - aws-cli/setup:
+                role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile-name: "OIDC-User"
           attach-workspace: true
-          role-arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           region: "us-west-2"
-          assume-web-identity: true
           profile-name: "OIDC-User"
           context: [CPE-OIDC]
           workspace-root: workspace
@@ -183,7 +185,6 @@ workflows:
           path: workspace
           extra-build-args: --compress
           skip-when-tags-exist: true
-          aws-cli-version: 2.4.10
           post-steps:
             - run:
                 name: "Delete repository"
@@ -192,25 +193,17 @@ workflows:
           matrix:
             parameters:
               executor: ["amd64", "arm64"]
-          filters:
-            tags:
-              only: /.*/
+          filters: *filters
           requires:
             - integration-tests-skip-when-tags-exist-populate-image-amd64
             - integration-tests-skip-when-tags-exist-populate-image-arm64
 
       - orb-tools/lint:
-          filters:
-            tags:
-              only: /.*/
+          filters: *filters
       - orb-tools/pack:
-          filters:
-            tags:
-              only: /.*/
+          filters: *filters
       - orb-tools/review:
-          filters:
-            tags:
-              only: /.*/
+          filters: *filters
       - orb-tools/publish:
           orb-name: circleci/aws-ecr
           vcs-type: << pipeline.project.type >>

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,6 +6,3 @@ description: >
 display:
   source_url: https://github.com/CircleCI-Public/aws-ecr-orb
   home_url: https://aws.amazon.com/ecr/
-
-orbs:
-  aws-cli: circleci/aws-cli@3.1.3

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -17,54 +17,54 @@ parameters:
     description: AWS profile name to be configured.
     type: string
 
-  aws-access-key-id:
-    default: AWS_ACCESS_KEY_ID
-    description: >
-      AWS access key id for IAM role. Set this to the name of the environment
-      variable you will set to hold this value, i.e. AWS_ACCESS_KEY_ID.
-    type: env_var_name
+  # aws-access-key-id:
+  #   default: AWS_ACCESS_KEY_ID
+  #   description: >
+  #     AWS access key id for IAM role. Set this to the name of the environment
+  #     variable you will set to hold this value, i.e. AWS_ACCESS_KEY_ID.
+  #   type: env_var_name
 
-  aws-secret-access-key:
-    default: AWS_SECRET_ACCESS_KEY
-    description: >
-      AWS secret key for IAM role. Set this to the name of the environment
-      variable you will set to hold this value, i.e. AWS_SECRET_ACCESS_KEY.
-    type: env_var_name
+  # aws-secret-access-key:
+  #   default: AWS_SECRET_ACCESS_KEY
+  #   description: >
+  #     AWS secret key for IAM role. Set this to the name of the environment
+  #     variable you will set to hold this value, i.e. AWS_SECRET_ACCESS_KEY.
+  #   type: env_var_name
 
-  role-arn:
-    type: string
-    default: ""
-    description: Role ARN that the profile should take.
+  # role-arn:
+  #   type: string
+  #   default: ""
+  #   description: Role ARN that the profile should take.
 
-  role-session-name:
-    description: An identifier for the assumed role session
-    type: string
-    default: ${CIRCLE_JOB}
+  # role-session-name:
+  #   description: An identifier for the assumed role session
+  #   type: string
+  #   default: ${CIRCLE_JOB}
 
-  session-duration:
-    description: The duration of the session in seconds
-    type: string
-    default: "3600"
+  # session-duration:
+  #   description: The duration of the session in seconds
+  #   type: string
+  #   default: "3600"
 
-  assume-web-identity:
-    description: Set to true to configure a profile using short-term credentials
-    type: boolean
-    default: false
+  # assume-web-identity:
+  #   description: Set to true to configure a profile using short-term credentials
+  #   type: boolean
+  #   default: false
 
-  source-profile:
-    description: Source profile containing credentials to assume the role with role-arn.
-    type: string
-    default: "default"
+  # source-profile:
+  #   description: Source profile containing credentials to assume the role with role-arn.
+  #   type: string
+  #   default: "default"
 
-  new-profile-name:
-    description: Name of new profile associated with role arn.
-    type: string
-    default: ""
+  # new-profile-name:
+  #   description: Name of new profile associated with role arn.
+  #   type: string
+  #   default: ""
 
-  aws-cli-version:
-    description: Select a specific version of the AWS v2 CLI. By default the latest version will be used.
-    default: latest
-    type: string
+  # aws-cli-version:
+  #   description: Select a specific version of the AWS v2 CLI. By default the latest version will be used.
+  #   default: latest
+  #   type: string
 
   region:
     default: ${AWS_REGION}
@@ -171,6 +171,7 @@ parameters:
     description: >-
       Path to the directory containing your build context. Defaults to . (working directory).
     type: string
+
   extra-build-args:
     default: ""
     description: >
@@ -229,6 +230,11 @@ parameters:
     default: ""
     description: |
       The path to the .json file containing the repository policy to be applied to a specified repository in AWS ECR.
+  auth:
+    description: |
+      The authentication method used to access your AWS account. Import the aws-cli orb in your config and
+      provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
+    type: steps
 
 steps:
   - when:
@@ -253,20 +259,21 @@ steps:
         - setup_remote_docker:
             docker_layer_caching: <<parameters.remote-docker-layer-caching>>
             version: <<parameters.remote-docker-version>>
+  - steps: <<parameters.auth>>
   - ecr-login:
-      profile-name: <<parameters.profile-name>>
+      # profile-name: <<parameters.profile-name>>
       region: <<parameters.region>>
       registry-id: <<parameters.registry-id>>
-      aws-access-key-id: <<parameters.aws-access-key-id>>
-      aws-secret-access-key: <<parameters.aws-secret-access-key>>
-      aws-cli-version: <<parameters.aws-cli-version>>
+      # aws-access-key-id: <<parameters.aws-access-key-id>>
+      # aws-secret-access-key: <<parameters.aws-secret-access-key>>
+      # aws-cli-version: <<parameters.aws-cli-version>>
       public-registry: <<parameters.public-registry>>
-      role-arn: <<parameters.role-arn>>
-      assume-web-identity: <<parameters.assume-web-identity>>
-      role-session-name: <<parameters.role-session-name>>
-      session-duration: <<parameters.session-duration>>
-      new-profile-name: <<parameters.new-profile-name>>
-      source-profile: <<parameters.source-profile>>
+      # role-arn: <<parameters.role-arn>>
+      # assume-web-identity: <<parameters.assume-web-identity>>
+      # role-session-name: <<parameters.role-session-name>>
+      # session-duration: <<parameters.session-duration>>
+      # new-profile-name: <<parameters.new-profile-name>>
+      # source-profile: <<parameters.source-profile>>
 
   - when:
       condition: <<parameters.create-repo>>
@@ -294,50 +301,21 @@ steps:
         - run: >
             docker login -u $<<parameters.dockerhub-username>> -p
             $<<parameters.dockerhub-password>>
-  - when:
-      condition:
-        and:
-          - <<parameters.role-arn>>
-          - <<parameters.new-profile-name>>
-      steps:
-        - build-image:
-            registry-id: <<parameters.registry-id>>
-            repo: <<parameters.repo>>
-            tag: <<parameters.tag>>
-            dockerfile: <<parameters.dockerfile>>
-            path: <<parameters.path>>
-            extra-build-args: <<parameters.extra-build-args>>
-            no-output-timeout: <<parameters.no-output-timeout>>
-            skip-when-tags-exist: <<parameters.skip-when-tags-exist>>
-            profile-name: <<parameters.new-profile-name>>
-            platform: <<parameters.platform>>
-            region: <<parameters.region>>
-            public-registry: <<parameters.public-registry>>
-            push-image: <<parameters.push-image>>
-            lifecycle-policy-path: <<parameters.lifecycle-policy-path>>
-            public-registry-alias: <<parameters.public-registry-alias>>
-            build-path: <<parameters.build-path>>
 
-  - unless:
-      condition:
-        and:
-          - <<parameters.role-arn>>
-          - <<parameters.new-profile-name>>
-      steps:
-        - build-image:
-            registry-id: <<parameters.registry-id>>
-            repo: <<parameters.repo>>
-            tag: <<parameters.tag>>
-            dockerfile: <<parameters.dockerfile>>
-            path: <<parameters.path>>
-            extra-build-args: <<parameters.extra-build-args>>
-            no-output-timeout: <<parameters.no-output-timeout>>
-            skip-when-tags-exist: <<parameters.skip-when-tags-exist>>
-            profile-name: <<parameters.profile-name>>
-            platform: <<parameters.platform>>
-            region: <<parameters.region>>
-            public-registry: <<parameters.public-registry>>
-            push-image: <<parameters.push-image>>
-            lifecycle-policy-path: <<parameters.lifecycle-policy-path>>
-            public-registry-alias: <<parameters.public-registry-alias>>
-            build-path: <<parameters.build-path>>
+  - build-image:
+      registry-id: <<parameters.registry-id>>
+      repo: <<parameters.repo>>
+      tag: <<parameters.tag>>
+      dockerfile: <<parameters.dockerfile>>
+      path: <<parameters.path>>
+      extra-build-args: <<parameters.extra-build-args>>
+      no-output-timeout: <<parameters.no-output-timeout>>
+      skip-when-tags-exist: <<parameters.skip-when-tags-exist>>
+      profile-name: <<parameters.new-profile-name>>
+      platform: <<parameters.platform>>
+      region: <<parameters.region>>
+      public-registry: <<parameters.public-registry>>
+      push-image: <<parameters.push-image>>
+      lifecycle-policy-path: <<parameters.lifecycle-policy-path>>
+      public-registry-alias: <<parameters.public-registry-alias>>
+      build-path: <<parameters.build-path>>

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -7,7 +7,7 @@ description: >
 parameters:
   registry-id:
     type: env_var_name
-    default: AWS_ECR_REGISTRY_ID
+    default: AWS_ACCOUNT_ID
     description: >
       The 12 digit AWS id associated with the ECR account.
       This field is required
@@ -16,55 +16,6 @@ parameters:
     default: default
     description: AWS profile name to be configured.
     type: string
-
-  # aws-access-key-id:
-  #   default: AWS_ACCESS_KEY_ID
-  #   description: >
-  #     AWS access key id for IAM role. Set this to the name of the environment
-  #     variable you will set to hold this value, i.e. AWS_ACCESS_KEY_ID.
-  #   type: env_var_name
-
-  # aws-secret-access-key:
-  #   default: AWS_SECRET_ACCESS_KEY
-  #   description: >
-  #     AWS secret key for IAM role. Set this to the name of the environment
-  #     variable you will set to hold this value, i.e. AWS_SECRET_ACCESS_KEY.
-  #   type: env_var_name
-
-  # role-arn:
-  #   type: string
-  #   default: ""
-  #   description: Role ARN that the profile should take.
-
-  # role-session-name:
-  #   description: An identifier for the assumed role session
-  #   type: string
-  #   default: ${CIRCLE_JOB}
-
-  # session-duration:
-  #   description: The duration of the session in seconds
-  #   type: string
-  #   default: "3600"
-
-  # assume-web-identity:
-  #   description: Set to true to configure a profile using short-term credentials
-  #   type: boolean
-  #   default: false
-
-  # source-profile:
-  #   description: Source profile containing credentials to assume the role with role-arn.
-  #   type: string
-  #   default: "default"
-
-  # new-profile-name:
-  #   description: Name of new profile associated with role arn.
-  #   type: string
-  #   default: ""
-
-  # aws-cli-version:
-  #   description: Select a specific version of the AWS v2 CLI. By default the latest version will be used.
-  #   default: latest
-  #   type: string
 
   region:
     default: ${AWS_REGION}
@@ -261,20 +212,10 @@ steps:
             version: <<parameters.remote-docker-version>>
   - steps: <<parameters.auth>>
   - ecr-login:
-      # profile-name: <<parameters.profile-name>>
+      profile-name: <<parameters.profile-name>>
       region: <<parameters.region>>
       registry-id: <<parameters.registry-id>>
-      # aws-access-key-id: <<parameters.aws-access-key-id>>
-      # aws-secret-access-key: <<parameters.aws-secret-access-key>>
-      # aws-cli-version: <<parameters.aws-cli-version>>
       public-registry: <<parameters.public-registry>>
-      # role-arn: <<parameters.role-arn>>
-      # assume-web-identity: <<parameters.assume-web-identity>>
-      # role-session-name: <<parameters.role-session-name>>
-      # session-duration: <<parameters.session-duration>>
-      # new-profile-name: <<parameters.new-profile-name>>
-      # source-profile: <<parameters.source-profile>>
-
   - when:
       condition: <<parameters.create-repo>>
       steps:
@@ -284,7 +225,6 @@ steps:
             repo: <<parameters.repo>>
             repo-scan-on-push: <<parameters.repo-scan-on-push>>
             public-registry: <<parameters.public-registry>>
-
   - when:
       condition: <<parameters.set-repo-policy>>
       steps:
@@ -294,14 +234,12 @@ steps:
             repo: <<parameters.repo>>
             public-registry: <<parameters.public-registry>>
             repo-policy-path: <<parameters.repo-policy-path>>
-
   - when:
       condition: <<parameters.docker-login>>
       steps:
         - run: >
             docker login -u $<<parameters.dockerhub-username>> -p
             $<<parameters.dockerhub-password>>
-
   - build-image:
       registry-id: <<parameters.registry-id>>
       repo: <<parameters.repo>>
@@ -311,7 +249,7 @@ steps:
       extra-build-args: <<parameters.extra-build-args>>
       no-output-timeout: <<parameters.no-output-timeout>>
       skip-when-tags-exist: <<parameters.skip-when-tags-exist>>
-      profile-name: <<parameters.new-profile-name>>
+      profile-name: <<parameters.profile-name>>
       platform: <<parameters.platform>>
       region: <<parameters.region>>
       public-registry: <<parameters.public-registry>>

--- a/src/commands/build-and-push-image.yml
+++ b/src/commands/build-and-push-image.yml
@@ -18,10 +18,10 @@ parameters:
     type: string
 
   region:
-    default: ${AWS_REGION}
+    default: ${AWS_DEFAULT_REGION}
     description: >
       Name of env var storing your AWS region information, defaults to
-      AWS_REGION
+      AWS_DEFAULT_REGION
     type: string
 
   public-registry:

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -3,7 +3,7 @@ description: "Build a docker image with Docker Buildx"
 parameters:
   registry-id:
     type: env_var_name
-    default: AWS_ECR_REGISTRY_ID
+    default: AWS_ACCOUNT_ID
     description: >
       The 12 digit AWS Registry ID associated with the ECR account.
       This field is required

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -53,9 +53,9 @@ parameters:
 
   region:
     type: string
-    default: ${AWS_REGION}
+    default: ${AWS_DEFAULT_REGION}
     description: >
-      AWS region of ECR repository. Defaults to environment variable ${AWS_REGION}
+      AWS region of ECR repository. Defaults to environment variable ${AWS_DEFAULT_REGION}
 
   profile-name:
     type: string

--- a/src/commands/create-repo.yml
+++ b/src/commands/create-repo.yml
@@ -8,9 +8,9 @@ parameters:
 
   region:
     type: string
-    default: ${AWS_REGION}
+    default: ${AWS_DEFAULT_REGION}
     description: >
-      AWS region of ECR repository. Defaults to environment variable ${AWS_REGION}
+      AWS region of ECR repository. Defaults to environment variable ${AWS_DEFAULT_REGION}
 
   repo:
     type: string

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -10,9 +10,9 @@ parameters:
 
   region:
     type: string
-    default: ${AWS_REGION}
+    default: ${AWS_DEFAULT_REGION}
     description: >
-      AWS region of ECR repository. Defaults to environment variable ${AWS_REGION}
+      AWS region of ECR repository. Defaults to environment variable ${AWS_DEFAULT_REGION}
 
   profile-name:
     type: string

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -3,7 +3,7 @@ description: "Authenticate into the Amazon ECR service"
 parameters:
   registry-id:
     type: env_var_name
-    default: AWS_ECR_REGISTRY_ID
+    default: AWS_ACCOUNT_ID
     description: >
       The 12 digit AWS id associated with the ECR account.
       This field is required
@@ -20,118 +20,17 @@ parameters:
     description: >
       AWS profile name to be used for login.
 
-  # role-arn:
-  #   type: string
-  #   default: ""
-  #   description: Role ARN that the profile should take.
-
-  # role-session-name:
-  #   description: An identifier for the assumed role session
-  #   type: string
-  #   default: ${CIRCLE_JOB}
-
-  # session-duration:
-  #   description: The duration of the session in seconds
-  #   type: string
-  #   default: "3600"
-
-  # assume-web-identity:
-  #   description: Set to true to configure a profile using short-term credentials
-  #   type: boolean
-  #   default: false
-
-  # source-profile:
-  #   description: Source profile containing credentials to assume the role with role-arn.
-  #   type: string
-  #   default: "default"
-
-  # new-profile-name:
-  #   type: string
-  #   default: ""
-  #   description: Name of new profile associated with role arn.
-
-  # aws-access-key-id:
-  #   type: env_var_name
-  #   default: AWS_ACCESS_KEY_ID
-  #   description: >
-  #     AWS access key id for IAM role. Set this to the name of
-  #     the environment variable you will set to hold this
-  #     value, i.e. AWS_ACCESS_KEY.
-
-  # aws-secret-access-key:
-  #   type: env_var_name
-  #   default: AWS_SECRET_ACCESS_KEY
-  #   description: >
-  #     AWS secret key for IAM role. Set this to the name of
-  #     the environment variable you will set to hold this
-  #     value, i.e. AWS_SECRET_ACCESS_KEY.
-
-  # aws-cli-version:
-  #   description: Select a specific version of the AWS v2 CLI. By default the latest version will be used.
-  #   default: latest
-  #   type: string
-
   public-registry:
     type: boolean
     description: Set to true if building and pushing an image to a Public Registry on ECR.
     default: false
 
 steps:
-  # - when:
-  #     condition: <<parameters.assume-web-identity>>
-  #     steps:
-  #       - aws-cli/setup:
-  #           profile-name: <<parameters.profile-name>>
-  #           version: <<parameters.aws-cli-version>>
-  #           role-arn: <<parameters.role-arn>>
-  #           role-session-name: <<parameters.role-session-name>>
-  #           session-duration: <<parameters.session-duration>>
-  # - when:
-  #     condition:
-  #       not: <<parameters.assume-web-identity>>
-  #     steps:
-  #       - aws-cli/setup:
-  #           profile-name: <<parameters.profile-name>>
-  #           aws-access-key-id: <<parameters.aws-access-key-id>>
-  #           aws-secret-access-key: <<parameters.aws-secret-access-key>>
-  #           version: <<parameters.aws-cli-version>>
-
-  # - when:
-  #     condition:
-  #       and:
-  #         - <<parameters.role-arn>>
-  #         - <<parameters.source-profile>>
-  #         - <<parameters.new-profile-name>>
-  #     steps:
-  #       - aws-cli/role-arn-setup:
-  #           profile-name: <<parameters.new-profile-name>>
-  #           role-arn: <<parameters.role-arn>>
-  #           source-profile: <<parameters.source-profile>>
-  # - when:
-  #     condition:
-  #       and:
-  #         - <<parameters.role-arn>>
-  #         - <<parameters.new-profile-name>>
-  #     steps:
-  #       - run:
-  #           name: Log into Amazon ECR with profile <<parameters.new-profile-name>>
-  #           environment:
-  #             ORB_VAL_PROFILE_NAME: <<parameters.new-profile-name>>
-  #             ORB_ENV_REGISTRY_ID: <<parameters.registry-id>>
-  #             ORB_EVAL_REGION: <<parameters.region>>
-  #             ORB_VAL_PUBLIC_REGISTRY: <<parameters.public-registry>>
-  #           command: <<include(scripts/ecr-login.sh)>>
-  # - unless:
-  #     condition:
-  #       and:
-  #         - <<parameters.role-arn>>
-  #         - <<parameters.new-profile-name>>
-  #     steps:
-    - run:
-        name: Log into Amazon ECR with profile <<parameters.profile-name>>
-        environment:
-          ORB_VAL_PROFILE_NAME: <<parameters.profile-name>>
-          ORB_ENV_REGISTRY_ID: <<parameters.registry-id>>
-          ORB_EVAL_REGION: <<parameters.region>>
-          ORB_VAL_PUBLIC_REGISTRY: <<parameters.public-registry>>
-        command: <<include(scripts/ecr-login.sh)>>
+  - run:
+      name: Log into Amazon ECR with profile <<parameters.profile-name>>
+      environment:
+        ORB_VAL_PROFILE_NAME: <<parameters.profile-name>>
+        ORB_ENV_REGISTRY_ID: <<parameters.registry-id>>
+        ORB_EVAL_REGION: <<parameters.region>>
+        ORB_VAL_PUBLIC_REGISTRY: <<parameters.public-registry>>
+      command: <<include(scripts/ecr-login.sh)>>

--- a/src/commands/ecr-login.yml
+++ b/src/commands/ecr-login.yml
@@ -18,58 +18,58 @@ parameters:
     type: string
     default: "default"
     description: >
-      AWS profile name to be configured.
+      AWS profile name to be used for login.
 
-  role-arn:
-    type: string
-    default: ""
-    description: Role ARN that the profile should take.
+  # role-arn:
+  #   type: string
+  #   default: ""
+  #   description: Role ARN that the profile should take.
 
-  role-session-name:
-    description: An identifier for the assumed role session
-    type: string
-    default: ${CIRCLE_JOB}
+  # role-session-name:
+  #   description: An identifier for the assumed role session
+  #   type: string
+  #   default: ${CIRCLE_JOB}
 
-  session-duration:
-    description: The duration of the session in seconds
-    type: string
-    default: "3600"
+  # session-duration:
+  #   description: The duration of the session in seconds
+  #   type: string
+  #   default: "3600"
 
-  assume-web-identity:
-    description: Set to true to configure a profile using short-term credentials
-    type: boolean
-    default: false
+  # assume-web-identity:
+  #   description: Set to true to configure a profile using short-term credentials
+  #   type: boolean
+  #   default: false
 
-  source-profile:
-    description: Source profile containing credentials to assume the role with role-arn.
-    type: string
-    default: "default"
+  # source-profile:
+  #   description: Source profile containing credentials to assume the role with role-arn.
+  #   type: string
+  #   default: "default"
 
-  new-profile-name:
-    type: string
-    default: ""
-    description: Name of new profile associated with role arn.
+  # new-profile-name:
+  #   type: string
+  #   default: ""
+  #   description: Name of new profile associated with role arn.
 
-  aws-access-key-id:
-    type: env_var_name
-    default: AWS_ACCESS_KEY_ID
-    description: >
-      AWS access key id for IAM role. Set this to the name of
-      the environment variable you will set to hold this
-      value, i.e. AWS_ACCESS_KEY.
+  # aws-access-key-id:
+  #   type: env_var_name
+  #   default: AWS_ACCESS_KEY_ID
+  #   description: >
+  #     AWS access key id for IAM role. Set this to the name of
+  #     the environment variable you will set to hold this
+  #     value, i.e. AWS_ACCESS_KEY.
 
-  aws-secret-access-key:
-    type: env_var_name
-    default: AWS_SECRET_ACCESS_KEY
-    description: >
-      AWS secret key for IAM role. Set this to the name of
-      the environment variable you will set to hold this
-      value, i.e. AWS_SECRET_ACCESS_KEY.
+  # aws-secret-access-key:
+  #   type: env_var_name
+  #   default: AWS_SECRET_ACCESS_KEY
+  #   description: >
+  #     AWS secret key for IAM role. Set this to the name of
+  #     the environment variable you will set to hold this
+  #     value, i.e. AWS_SECRET_ACCESS_KEY.
 
-  aws-cli-version:
-    description: Select a specific version of the AWS v2 CLI. By default the latest version will be used.
-    default: latest
-    type: string
+  # aws-cli-version:
+  #   description: Select a specific version of the AWS v2 CLI. By default the latest version will be used.
+  #   default: latest
+  #   type: string
 
   public-registry:
     type: boolean
@@ -77,61 +77,61 @@ parameters:
     default: false
 
 steps:
-  - when:
-      condition: <<parameters.assume-web-identity>>
-      steps:
-        - aws-cli/setup:
-            profile-name: <<parameters.profile-name>>
-            version: <<parameters.aws-cli-version>>
-            role-arn: <<parameters.role-arn>>
-            role-session-name: <<parameters.role-session-name>>
-            session-duration: <<parameters.session-duration>>
-  - when:
-      condition:
-        not: <<parameters.assume-web-identity>>
-      steps:
-        - aws-cli/setup:
-            profile-name: <<parameters.profile-name>>
-            aws-access-key-id: <<parameters.aws-access-key-id>>
-            aws-secret-access-key: <<parameters.aws-secret-access-key>>
-            version: <<parameters.aws-cli-version>>
+  # - when:
+  #     condition: <<parameters.assume-web-identity>>
+  #     steps:
+  #       - aws-cli/setup:
+  #           profile-name: <<parameters.profile-name>>
+  #           version: <<parameters.aws-cli-version>>
+  #           role-arn: <<parameters.role-arn>>
+  #           role-session-name: <<parameters.role-session-name>>
+  #           session-duration: <<parameters.session-duration>>
+  # - when:
+  #     condition:
+  #       not: <<parameters.assume-web-identity>>
+  #     steps:
+  #       - aws-cli/setup:
+  #           profile-name: <<parameters.profile-name>>
+  #           aws-access-key-id: <<parameters.aws-access-key-id>>
+  #           aws-secret-access-key: <<parameters.aws-secret-access-key>>
+  #           version: <<parameters.aws-cli-version>>
 
-  - when:
-      condition:
-        and:
-          - <<parameters.role-arn>>
-          - <<parameters.source-profile>>
-          - <<parameters.new-profile-name>>
-      steps:
-        - aws-cli/role-arn-setup:
-            profile-name: <<parameters.new-profile-name>>
-            role-arn: <<parameters.role-arn>>
-            source-profile: <<parameters.source-profile>>
-  - when:
-      condition:
-        and:
-          - <<parameters.role-arn>>
-          - <<parameters.new-profile-name>>
-      steps:
-        - run:
-            name: Log into Amazon ECR with profile <<parameters.new-profile-name>>
-            environment:
-              ORB_VAL_PROFILE_NAME: <<parameters.new-profile-name>>
-              ORB_ENV_REGISTRY_ID: <<parameters.registry-id>>
-              ORB_EVAL_REGION: <<parameters.region>>
-              ORB_VAL_PUBLIC_REGISTRY: <<parameters.public-registry>>
-            command: <<include(scripts/ecr-login.sh)>>
-  - unless:
-      condition:
-        and:
-          - <<parameters.role-arn>>
-          - <<parameters.new-profile-name>>
-      steps:
-        - run:
-            name: Log into Amazon ECR with profile <<parameters.profile-name>>
-            environment:
-              ORB_VAL_PROFILE_NAME: <<parameters.profile-name>>
-              ORB_ENV_REGISTRY_ID: <<parameters.registry-id>>
-              ORB_EVAL_REGION: <<parameters.region>>
-              ORB_VAL_PUBLIC_REGISTRY: <<parameters.public-registry>>
-            command: <<include(scripts/ecr-login.sh)>>
+  # - when:
+  #     condition:
+  #       and:
+  #         - <<parameters.role-arn>>
+  #         - <<parameters.source-profile>>
+  #         - <<parameters.new-profile-name>>
+  #     steps:
+  #       - aws-cli/role-arn-setup:
+  #           profile-name: <<parameters.new-profile-name>>
+  #           role-arn: <<parameters.role-arn>>
+  #           source-profile: <<parameters.source-profile>>
+  # - when:
+  #     condition:
+  #       and:
+  #         - <<parameters.role-arn>>
+  #         - <<parameters.new-profile-name>>
+  #     steps:
+  #       - run:
+  #           name: Log into Amazon ECR with profile <<parameters.new-profile-name>>
+  #           environment:
+  #             ORB_VAL_PROFILE_NAME: <<parameters.new-profile-name>>
+  #             ORB_ENV_REGISTRY_ID: <<parameters.registry-id>>
+  #             ORB_EVAL_REGION: <<parameters.region>>
+  #             ORB_VAL_PUBLIC_REGISTRY: <<parameters.public-registry>>
+  #           command: <<include(scripts/ecr-login.sh)>>
+  # - unless:
+  #     condition:
+  #       and:
+  #         - <<parameters.role-arn>>
+  #         - <<parameters.new-profile-name>>
+  #     steps:
+    - run:
+        name: Log into Amazon ECR with profile <<parameters.profile-name>>
+        environment:
+          ORB_VAL_PROFILE_NAME: <<parameters.profile-name>>
+          ORB_ENV_REGISTRY_ID: <<parameters.registry-id>>
+          ORB_EVAL_REGION: <<parameters.region>>
+          ORB_VAL_PUBLIC_REGISTRY: <<parameters.public-registry>>
+        command: <<include(scripts/ecr-login.sh)>>

--- a/src/commands/push-image.yml
+++ b/src/commands/push-image.yml
@@ -8,9 +8,9 @@ parameters:
       This field is required
   region:
     type: string
-    default: ${AWS_REGION}
+    default: ${AWS_DEFAULT_REGION}
     description: >
-      AWS region of ECR repository. Defaults to environment variable ${AWS_REGION}
+      AWS region of ECR repository. Defaults to environment variable ${AWS_DEFAULT_REGION}
   repo:
     description: Name of an Amazon ECR repository
     type: string

--- a/src/commands/push-image.yml
+++ b/src/commands/push-image.yml
@@ -2,7 +2,7 @@ description: Push a container image to the Amazon ECR registry
 parameters:
   registry-id:
     type: env_var_name
-    default: AWS_ECR_REGISTRY_ID
+    default: AWS_ACCOUNT_ID
     description: >
       The 12 digit AWS Registry ID associated with the ECR account.
       This field is required

--- a/src/commands/set-repo-policy.yml
+++ b/src/commands/set-repo-policy.yml
@@ -8,9 +8,9 @@ parameters:
 
   region:
     type: string
-    default: ${AWS_REGION}
+    default: ${AWS_DEFAULT_REGION}
     description: >
-      AWS region of ECR repository. Defaults to environment variable ${AWS_REGION}
+      AWS region of ECR repository. Defaults to environment variable ${AWS_DEFAULT_REGION}
 
   repo:
     type: string

--- a/src/examples/simple-build-and-push.yml
+++ b/src/examples/simple-build-and-push.yml
@@ -45,7 +45,7 @@ usage:
             region: AWS_REGION
 
             # name of env var storing your ECR Registry ID
-            registry-id: AWS_ECR_REGISTRY_ID
+            registry-id: AWS_ACCOUNT_ID
 
             # ECR image tags (comma separated string), defaults to "latest"
             tag: latest,myECRRepoTag

--- a/src/examples/simple-build-and-push.yml
+++ b/src/examples/simple-build-and-push.yml
@@ -1,18 +1,36 @@
-description: Log into AWS, build and push image to Amazon ECR
+description: >
+  Log into AWS, build and push image to Amazon ECR using OIDC for authentication.
+  Import the aws-cli orb and authenticate using the aws-cli/setup command with a valid role-arn for OIDC authentication.
 
 usage:
   version: 2.1
 
   orbs:
-    aws-ecr: circleci/aws-ecr@x.y
+    aws-ecr: circleci/aws-ecr@9.0
+    # Importing aws-cli orb is required
+    aws-cli: circleci/aws-cli@3.1
+
+  executors:
+    base:
+      docker:
+        image: cimg/base:current
 
   workflows:
     build_and_push_image:
       jobs:
         # build and push image to ECR
         - aws-ecr/build-and-push-image:
+            auth:
+               # Add authentication step with OIDC using aws-cli/setup command
+              - aws-cli/setup:
+                  profile: "OIDC-USER"
+                  role-arn: "arn:aws:iam::123456789012:role/VALID_OIDC_ECR_ROLE"
+
+            # Must use same profile configured in aws-cli/setup command
+            profile-name: "OIDC-User"
+
             # Select executor defined above
-            executor: aws-ecr/default
+            executors: base
 
             # name of your ECR repository
             repo: myECRRepository
@@ -20,29 +38,11 @@ usage:
             # set this to true to create the repository if it does not already exist, defaults to "false"
             create-repo: true
 
-            # required if any necessary secrets are stored via Contexts
-            context: myContext
-
-            # AWS profile name, defaults to "default"
-            profile-name: myProfileName
-
-            # name of env var storing your AWS Access Key ID, defaults to AWS_ACCESS_KEY_ID
-            aws-access-key-id: ACCESS_KEY_ID_ENV_VAR_NAME
-
-            # name of env var storing your AWS Secret Access Key, defaults to AWS_SECRET_ACCESS_KEY
-            aws-secret-access-key: SECRET_ACCESS_KEY_ENV_VAR_NAME
-
-            # Name of new profile associated with role arn.
-            new-profile-name: newProfileName
-
-            # Source profile containing credentials to assume the role with role-arn.
-            source-profile: sourceProfileName
-
-            # Role ARN that new profile should take
-            role-arn: arn:aws:iam::123456789012:role/testing
+            # Must use valid CircleCI context for OIDC authentication
+            context: CircleCI_OIDC_Token
 
             #Your AWS region
-            region: AWS_REGION
+            region: ${AWS_DEFAULT_REGION}
 
             # name of env var storing your ECR Registry ID
             registry-id: AWS_ACCOUNT_ID
@@ -55,9 +55,6 @@ usage:
 
             # path to Dockerfile, defaults to . (working directory)
             path: pathToMyDockerfile
-
-            # Select a specific version of the AWS v2 CLI. By default the latest version will be used.
-            aws-cli-version: latest
 
             # Boolean value if pushing to public registry. Defaults to true.
             public-registry: false

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -26,21 +26,21 @@ parameters:
     default: "default"
     description: AWS profile name to be configured.
 
-  aws-access-key-id:
-    type: env_var_name
-    default: AWS_ACCESS_KEY_ID
-    description: >
-      AWS access key id for IAM role. Set this to the name of
-      the environment variable you will set to hold this
-      value, i.e. AWS_ACCESS_KEY_ID.
+  # aws-access-key-id:
+  #   type: env_var_name
+  #   default: AWS_ACCESS_KEY_ID
+  #   description: >
+  #     AWS access key id for IAM role. Set this to the name of
+  #     the environment variable you will set to hold this
+  #     value, i.e. AWS_ACCESS_KEY_ID.
 
-  aws-secret-access-key:
-    type: env_var_name
-    default: AWS_SECRET_ACCESS_KEY
-    description: >
-      AWS secret key for IAM role. Set this to the name of
-      the environment variable you will set to hold this
-      value, i.e. AWS_SECRET_ACCESS_KEY.
+  # aws-secret-access-key:
+  #   type: env_var_name
+  #   default: AWS_SECRET_ACCESS_KEY
+  #   description: >
+  #     AWS secret key for IAM role. Set this to the name of
+  #     the environment variable you will set to hold this
+  #     value, i.e. AWS_SECRET_ACCESS_KEY.
 
   checkout:
     default: true
@@ -48,40 +48,40 @@ parameters:
       Boolean for whether or not to checkout as a first step. Default is true.
     type: boolean
 
-  role-arn:
-    type: string
-    default: ""
-    description: Role ARN that the profile should take.
+  # role-arn:
+  #   type: string
+  #   default: ""
+  #   description: Role ARN that the profile should take.
 
-  role-session-name:
-    description: An identifier for the assumed role session
-    type: string
-    default: ${CIRCLE_JOB}
+  # role-session-name:
+  #   description: An identifier for the assumed role session
+  #   type: string
+  #   default: ${CIRCLE_JOB}
 
-  assume-web-identity:
-    description: Set to true to configure a profile using short-term credentials
-    type: boolean
-    default: false
+  # assume-web-identity:
+  #   description: Set to true to configure a profile using short-term credentials
+  #   type: boolean
+  #   default: false
 
-  session-duration:
-    description: The duration of the session in seconds
-    type: string
-    default: "3600"
+  # session-duration:
+  #   description: The duration of the session in seconds
+  #   type: string
+  #   default: "3600"
 
-  source-profile:
-    description: Source profile containing credentials to assume the role with role-arn.
-    type: string
-    default: "default"
+  # source-profile:
+  #   description: Source profile containing credentials to assume the role with role-arn.
+  #   type: string
+  #   default: "default"
 
-  new-profile-name:
-    description: Name of new profile associated with role arn.
-    type: string
-    default: ""
+  # new-profile-name:
+  #   description: Name of new profile associated with role arn.
+  #   type: string
+  #   default: ""
 
-  aws-cli-version:
-    description: Select a specific version of the AWS v2 CLI. By default the latest version will be used.
-    default: latest
-    type: string
+  # aws-cli-version:
+  #   description: Select a specific version of the AWS v2 CLI. By default the latest version will be used.
+  #   default: latest
+  #   type: string
 
   region:
     type: string
@@ -230,6 +230,12 @@ parameters:
     description: |
       The path to the .json file containing the repository policy to be applied to a specified repository in AWS ECR.
 
+  auth:
+    description: |
+      The authentication method used to access your AWS account. Import the aws-cli orb in your config and
+      provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
+    type: steps
+
 steps:
   - build-and-push-image:
       registry-id: <<parameters.registry-id>>
@@ -247,16 +253,16 @@ steps:
       push-image: <<parameters.push-image>>
       lifecycle-policy-path: <<parameters.lifecycle-policy-path>>
       repo-scan-on-push: <<parameters.repo-scan-on-push>>
-      aws-access-key-id: <<parameters.aws-access-key-id>>
-      aws-secret-access-key: <<parameters.aws-secret-access-key>>
+      # aws-access-key-id: <<parameters.aws-access-key-id>>
+      # aws-secret-access-key: <<parameters.aws-secret-access-key>>
       checkout: <<parameters.checkout>>
-      aws-cli-version: <<parameters.aws-cli-version>>
-      role-arn: <<parameters.role-arn>>
-      role-session-name: <<parameters.role-session-name>>
-      assume-web-identity: <<parameters.assume-web-identity>>
-      session-duration: <<parameters.session-duration>>
-      new-profile-name: <<parameters.new-profile-name>>
-      source-profile: <<parameters.source-profile>>
+      # aws-cli-version: <<parameters.aws-cli-version>>
+      # role-arn: <<parameters.role-arn>>
+      # role-session-name: <<parameters.role-session-name>>
+      # assume-web-identity: <<parameters.assume-web-identity>>
+      # session-duration: <<parameters.session-duration>>
+      # new-profile-name: <<parameters.new-profile-name>>
+      # source-profile: <<parameters.source-profile>>
       attach-workspace: <<parameters.attach-workspace>>
       remote-docker-layer-caching: <<parameters.remote-docker-layer-caching>>
       setup-remote-docker: <<parameters.setup-remote-docker>>
@@ -269,3 +275,4 @@ steps:
       public-registry-alias: <<parameters.public-registry-alias>>
       set-repo-policy: <<parameters.set-repo-policy>>
       repo-policy-path: <<parameters.repo-policy-path>>
+      auth: <<parameters.auth>>

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -16,7 +16,7 @@ parameters:
 
   registry-id:
     type: env_var_name
-    default: AWS_ECR_REGISTRY_ID
+    default: AWS_ACCOUNT_ID
     description: >
       The 12 digit AWS id associated with the ECR account.
       This field is required

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -85,9 +85,9 @@ parameters:
 
   region:
     type: string
-    default: ${AWS_REGION}
+    default: ${AWS_DEFAULT_REGION}
     description: >
-      AWS region of ECR repository. Defaults to environment variable ${AWS_REGION}
+      AWS region of ECR repository. Defaults to environment variable ${AWS_DEFAULT_REGION}
 
   public-registry:
     type: boolean


### PR DESCRIPTION
This `PR` adds the `auth` parameter to the `build-and-push` job, requiring users to customize their authentication method by importing the `aws-cli` orb and using the `aws-cli/setup` command to authenticate using static AWS keys or a valid `role-arn` for OIDC.