### PR TITLE
fix: add docker logout command to clear expired token

### DIFF
--- a/src/scripts/ecr_login.sh
+++ b/src/scripts/ecr_login.sh
@@ -19,9 +19,9 @@ if [ -n "${ORB_STR_PROFILE_NAME}" ]; then
     set -- "$@" --profile "${ORB_STR_PROFILE_NAME}"
 fi
 
-# shellcheck disable=SC2002
-if [ -f "$HOME/.docker/config.json" ] && cat ~/.docker/config.json | grep "${ORB_VAL_ACCOUNT_URL}" > /dev/null 2>&1 ; then
+if [ -f "$HOME/.docker/config.json" ] && grep "${ORB_VAL_ACCOUNT_URL}" < ~/.docker/config.json > /dev/null 2>&1 ; then
     echo "Credential helper is already installed"
 else
+    docker logout "${ORB_VAL_ACCOUNT_URL}"    
     aws "${ECR_COMMAND}" get-login-password --region "${ORB_STR_REGION}" "$@" | docker login --username AWS --password-stdin "${ORB_VAL_ACCOUNT_URL}"
 fi


### PR DESCRIPTION
Currently, when a user runs the `aws-ecr/ecr_login` command successfully, a session token is generated and stored in the `~/.docker/config.json` file. However, this token is only valid for 12 hours. Some customers' build processes take longer than 12 hours. This causes subsequent steps to fail with the following error:

`ERROR: denied: Your authorization token has expired. Reauthenticate and try again.`

When trying to run the `aws-ecr/ecr_login` command again to log in, the build fails because it tries to use the existing token in `~/.docker/config.json` that's already expired. 

To solve this, I've added the `docker logout` command before running the `aws ecr login` command. The `docker logout` command automatically deletes any existing session token in `~/.docker/config.json`. This ensures that a fresh session token is generated with a successful login and any expired tokens will be deleted from the file