### PR TITLE
Adding support for third party container registries outside of Docker…

### DIFF
--- a/src/commands/build_and_push_image.yml
+++ b/src/commands/build_and_push_image.yml
@@ -103,6 +103,36 @@ parameters:
       environment variable you will set to hold this value, i.e.
       DOCKERHUB_PASSWORD.
     type: env_var_name
+  
+  third_party_login:
+    default: false
+    description: |
+      Enable github container registry authentication. Defaults to false.
+    type: boolean
+
+  third_party_url:
+    default: third_party_url
+    description: >
+      Third party registry url to be configured. Set this to the URL of the
+      environment variable you will set to hold this value, i.e. 
+      ghcr.io for Github or registry.heroku.com for Heroku
+    type: env_var_name
+
+  third_party_username:
+    default: third_party_username
+    description: >
+      Third party registry username to be configured. Set this to the name of the
+      environment variable you will set to hold this value, i.e.
+      third_party_username.
+    type: env_var_name
+
+  third_party_token:
+    default: third_party_token
+    description: >
+      Third party registry token to be configured. Set this to the name of the
+      environment variable you will set to hold this value, i.e.
+      third_party_token.
+    type: env_var_name
 
   dockerfile:
     default: Dockerfile
@@ -238,6 +268,12 @@ steps:
         - run: >
             docker login -u $<<parameters.dockerhub_username>> -p
             $<<parameters.dockerhub_password>>
+  - when:
+      condition: <<parameters.third_party_login>>
+      steps:
+        - run: >
+            docker login $<<parameters.third_party_url> -u $<<parameters.third_party_username>> -p
+            $<<parameters.third_party_token>>
   - build_image:
       registry_id: <<parameters.registry_id>>
       repo: <<parameters.repo>>

--- a/src/jobs/build_and_push_image.yml
+++ b/src/jobs/build_and_push_image.yml
@@ -115,6 +115,36 @@ parameters:
       the environment variable you will set to hold this
       value, i.e. DOCKERHUB_PASSWORD.
 
+  third_party_login:
+    default: false
+    description: |
+      Enable github container registry authentication. Defaults to false.
+    type: boolean
+  
+  third_party_url:
+    default: third_party_url
+    description: >
+      Third party registry url to be configured. Set this to the URL of the
+      environment variable you will set to hold this value, i.e. 
+      ghcr.io for Github or registry.heroku.com for Heroku
+    type: env_var_name
+
+  third_party_username:
+    default: THIRD_PARTY_USERNAME
+    description: >
+      Github username to be configured. Set this to the name of the
+      environment variable you will set to hold this value, i.e.
+      THIRD_PARTY_USERNAME.
+    type: env_var_name
+
+  third_party_token:
+    default: THIRD_PARTY_TOKEN
+    description: >
+      Github password to be configured. Set this to the name of the
+      environment variable you will set to hold this value, i.e.
+      THIRD_PARTY_TOKEN.
+    type: env_var_name
+
   dockerfile:
     type: string
     default: Dockerfile
@@ -216,6 +246,10 @@ steps:
       docker_login: <<parameters.docker_login>>
       dockerhub_username: <<parameters.dockerhub_username>>
       dockerhub_password: <<parameters.dockerhub_password>>
+      third_party_login: <<parameters.third_party_login>>
+      third_party_url: <<parameters.third_party_url>>
+      third_party_username: <<parameters.third_party_username>>
+      third_party_token: <<parameters.third_party_token>>
       public_registry_alias: <<parameters.public_registry_alias>>
       set_repo_policy: <<parameters.set_repo_policy>>
       repo_policy_path: <<parameters.repo_policy_path>>


### PR DESCRIPTION
… Hub

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses

-->

The reason for this is there is not currently a way to login to a repository other than DockerHub and there are other third party container registries someone may want to use such as Github or Heroku or others

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"


 -->

Added environment variables third_party_url, third_party_username, and third_party_token to build_and_push_image.yml

  Added additional when condtion for docker login using third party repository to build_and_push_image.yml

  Added environment variables third_party_url, third_party_username, and third_party_token to build_and_push_image.yml

  Added additional steps to build_and_push_image.yml