### PR TITLE
fix: remove load with multi-platform

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -53,12 +53,33 @@ workflows:
           name: pre-integration
           filters: *filters
       - aws-ecr/build_and_push_image:
-          name: integration-tests-default-profile
+          name: integration-test-multi-platform-without-push
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           attach_workspace: true
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-multi-platform-without-push
+          create_repo: true
+          context: [CPE_ORBS_AWS]
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          executor: amd64
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1}-multi-platform-without-push --force
           push_image: false
+          platform: linux/amd64,linux/arm64
+          filters: *filters
+          requires: [pre-integration]
+      - aws-ecr/build_and_push_image:
+          name: integration-test-default-profile
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          attach_workspace: true
           workspace_root: workspace
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
           create_repo: true
@@ -76,144 +97,144 @@ workflows:
           platform: linux/amd64,linux/arm64
           filters: *filters
           requires: [pre-integration]
-      # - aws-ecr/build_and_push_image:
-      #     name: integration-tests-pubic-registry
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #           profile_name: "OIDC-User"
-      #     attach_workspace: true
-      #     workspace_root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public_registry
-      #     create_repo: true
-      #     region: "us-west-2"
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: Dockerfile
-      #     path: ./sample
-      #     extra_build_args: --compress
-      #     executor: arm64
-      #     public_registry: true
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1}-public_registry --force --profile OIDC-User
-      #     platform: linux/arm64,linux/amd64
-      #     filters: *filters
-      #     requires: [pre-integration]
-      # - aws-ecr/build_and_push_image:
-      #     pre-steps:
-      #       - run:
-      #           name: "Export NPM_TOKEN"
-      #           command: echo 'export NPM_TOKEN="00000000-0000-0000-0000-000000000000"' >> "$BASH_ENV"
-      #     name: integration-tests-named-profile
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #           profile_name: "OIDC-User"
-      #     attach_workspace: true
-      #     region: "us-west-2"
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     workspace_root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-      #     create_repo: true
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     extra_build_args: '--build-arg NPM_TOKEN=${NPM_TOKEN} --build-arg=${CIRCLE_SHA1:0:7}'
-      #     set_repo_policy: true
-      #     repo_policy_path: ./sample/repo-policy.json
-      #     executor: amd64
-      #     filters: *filters
-      #     requires: [pre-integration]
-      # - tag-ecr-image:
-      #     name: integration-tests-tag-existing-image
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #           profile_name: "OIDC-User"
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-      #     region: "us-west-2"
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     source_tag: integration
-      #     target_tag: latest
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-named-profile --force --profile OIDC-User
-      #     filters: *filters
-      #     requires:
-      #       - integration-tests-named-profile
-      # - aws-ecr/build_and_push_image:
-      #     name: integration-tests-skip_when_tags_exist-populate-image-<<matrix.executor>>
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #           profile_name: "OIDC-User"
-      #     attach_workspace: true
-      #     region: "us-west-2"
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     workspace_root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
-      #     create_repo: true
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     extra_build_args: --compress
-      #     skip_when_tags_exist: true
-      #     matrix:
-      #       parameters:
-      #         executor: ["amd64", "arm64"]
-      #     filters: *filters
-      #     requires: [pre-integration]
-      # - aws-ecr/build_and_push_image:
-      #     name: integration-tests-skip_when_tags_exist-<<matrix.executor>>
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #           profile_name: "OIDC-User"
-      #     attach_workspace: true
-      #     region: "us-west-2"
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     workspace_root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     extra_build_args: --compress
-      #     skip_when_tags_exist: true
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: |
-      #             aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
-      #     matrix:
-      #       parameters:
-      #         executor: ["amd64", "arm64"]
-      #     filters: *filters
-      #     requires:
-      #       - integration-tests-skip_when_tags_exist-populate-image-amd64
-      #       - integration-tests-skip_when_tags_exist-populate-image-arm64
-      # - orb-tools/lint:
-      #     filters: *filters
-      # - orb-tools/pack:
-      #     filters: *filters
-      # - orb-tools/review:
-      #     filters: *release-filters
-      # - orb-tools/publish:
-      #     orb_name: circleci/aws-ecr
-      #     vcs_type: << pipeline.project.type >>
-      #     pub_type: production
-      #     enable_pr_comment: true
-      #     requires: [ orb-tools/lint, orb-tools/review, orb-tools/pack, integration-tests-default-profile, integration-tests-pubic-registry, integration-tests-skip_when_tags_exist-amd64, integration-tests-skip_when_tags_exist-arm64, integration-tests-named-profile, integration-tests-tag-existing-image ]
-      #     github_token: GHI_TOKEN
-      #     context: orb-publisher
-      #     filters: *release-filters
+      - aws-ecr/build_and_push_image:
+          name: integration-test-pubic-registry
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "OIDC-User"
+          attach_workspace: true
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public_registry
+          create_repo: true
+          region: "us-west-2"
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          tag: integration,myECRRepoTag
+          dockerfile: Dockerfile
+          path: ./sample
+          extra_build_args: --compress
+          executor: arm64
+          public_registry: true
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1}-public_registry --force --profile OIDC-User
+          platform: linux/arm64,linux/amd64
+          filters: *filters
+          requires: [pre-integration]
+      - aws-ecr/build_and_push_image:
+          pre-steps:
+            - run:
+                name: "Export NPM_TOKEN"
+                command: echo 'export NPM_TOKEN="00000000-0000-0000-0000-000000000000"' >> "$BASH_ENV"
+          name: integration-test-named-profile
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "OIDC-User"
+          attach_workspace: true
+          region: "us-west-2"
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+          create_repo: true
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra_build_args: '--build-arg NPM_TOKEN=${NPM_TOKEN} --build-arg=${CIRCLE_SHA1:0:7}'
+          set_repo_policy: true
+          repo_policy_path: ./sample/repo-policy.json
+          executor: amd64
+          filters: *filters
+          requires: [pre-integration]
+      - tag-ecr-image:
+          name: integration-test-tag-existing-image
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "OIDC-User"
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+          region: "us-west-2"
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          source_tag: integration
+          target_tag: latest
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-named-profile --force --profile OIDC-User
+          filters: *filters
+          requires:
+            - integration-test-named-profile
+      - aws-ecr/build_and_push_image:
+          name: integration-test-skip_when_tags_exist-populate-image-<<matrix.executor>>
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "OIDC-User"
+          attach_workspace: true
+          region: "us-west-2"
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
+          create_repo: true
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra_build_args: --compress
+          skip_when_tags_exist: true
+          matrix:
+            parameters:
+              executor: ["amd64", "arm64"]
+          filters: *filters
+          requires: [pre-integration]
+      - aws-ecr/build_and_push_image:
+          name: integration-test-skip_when_tags_exist-<<matrix.executor>>
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "OIDC-User"
+          attach_workspace: true
+          region: "us-west-2"
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra_build_args: --compress
+          skip_when_tags_exist: true
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: |
+                  aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
+          matrix:
+            parameters:
+              executor: ["amd64", "arm64"]
+          filters: *filters
+          requires:
+            - integration-test-skip_when_tags_exist-populate-image-amd64
+            - integration-test-skip_when_tags_exist-populate-image-arm64
+      - orb-tools/lint:
+          filters: *filters
+      - orb-tools/pack:
+          filters: *filters
+      - orb-tools/review:
+          filters: *release-filters
+      - orb-tools/publish:
+          orb_name: circleci/aws-ecr
+          vcs_type: << pipeline.project.type >>
+          pub_type: production
+          enable_pr_comment: true
+          requires: [ orb-tools/lint, orb-tools/review, orb-tools/pack, integration-test-default-profile, integration-test-pubic-registry, integration-test-skip_when_tags_exist-amd64, integration-test-skip_when_tags_exist-arm64, integration-test-named-profile, integration-test-tag-existing-image ]
+          github_token: GHI_TOKEN
+          context: orb-publisher
+          filters: *release-filters
 executors:
   amd64:
     machine:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -58,6 +58,7 @@ workflows:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           attach_workspace: true
+          push_image: false
           workspace_root: workspace
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
           create_repo: true
@@ -75,144 +76,144 @@ workflows:
           platform: linux/amd64,linux/arm64
           filters: *filters
           requires: [pre-integration]
-      - aws-ecr/build_and_push_image:
-          name: integration-tests-pubic-registry
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
-          attach_workspace: true
-          workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public_registry
-          create_repo: true
-          region: "us-west-2"
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          tag: integration,myECRRepoTag
-          dockerfile: Dockerfile
-          path: ./sample
-          extra_build_args: --compress
-          executor: arm64
-          public_registry: true
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1}-public_registry --force --profile OIDC-User
-          platform: linux/arm64,linux/amd64
-          filters: *filters
-          requires: [pre-integration]
-      - aws-ecr/build_and_push_image:
-          pre-steps:
-            - run:
-                name: "Export NPM_TOKEN"
-                command: echo 'export NPM_TOKEN="00000000-0000-0000-0000-000000000000"' >> "$BASH_ENV"
-          name: integration-tests-named-profile
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
-          attach_workspace: true
-          region: "us-west-2"
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-          create_repo: true
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra_build_args: '--build-arg NPM_TOKEN=${NPM_TOKEN} --build-arg=${CIRCLE_SHA1:0:7}'
-          set_repo_policy: true
-          repo_policy_path: ./sample/repo-policy.json
-          executor: amd64
-          filters: *filters
-          requires: [pre-integration]
-      - tag-ecr-image:
-          name: integration-tests-tag-existing-image
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-          region: "us-west-2"
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          source_tag: integration
-          target_tag: latest
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-named-profile --force --profile OIDC-User
-          filters: *filters
-          requires:
-            - integration-tests-named-profile
-      - aws-ecr/build_and_push_image:
-          name: integration-tests-skip_when_tags_exist-populate-image-<<matrix.executor>>
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
-          attach_workspace: true
-          region: "us-west-2"
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
-          create_repo: true
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra_build_args: --compress
-          skip_when_tags_exist: true
-          matrix:
-            parameters:
-              executor: ["amd64", "arm64"]
-          filters: *filters
-          requires: [pre-integration]
-      - aws-ecr/build_and_push_image:
-          name: integration-tests-skip_when_tags_exist-<<matrix.executor>>
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
-          attach_workspace: true
-          region: "us-west-2"
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra_build_args: --compress
-          skip_when_tags_exist: true
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: |
-                  aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
-          matrix:
-            parameters:
-              executor: ["amd64", "arm64"]
-          filters: *filters
-          requires:
-            - integration-tests-skip_when_tags_exist-populate-image-amd64
-            - integration-tests-skip_when_tags_exist-populate-image-arm64
-      - orb-tools/lint:
-          filters: *filters
-      - orb-tools/pack:
-          filters: *filters
-      - orb-tools/review:
-          filters: *release-filters
-      - orb-tools/publish:
-          orb_name: circleci/aws-ecr
-          vcs_type: << pipeline.project.type >>
-          pub_type: production
-          enable_pr_comment: true
-          requires: [ orb-tools/lint, orb-tools/review, orb-tools/pack, integration-tests-default-profile, integration-tests-pubic-registry, integration-tests-skip_when_tags_exist-amd64, integration-tests-skip_when_tags_exist-arm64, integration-tests-named-profile, integration-tests-tag-existing-image ]
-          github_token: GHI_TOKEN
-          context: orb-publisher
-          filters: *release-filters
+      # - aws-ecr/build_and_push_image:
+      #     name: integration-tests-pubic-registry
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #           profile_name: "OIDC-User"
+      #     attach_workspace: true
+      #     workspace_root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public_registry
+      #     create_repo: true
+      #     region: "us-west-2"
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: Dockerfile
+      #     path: ./sample
+      #     extra_build_args: --compress
+      #     executor: arm64
+      #     public_registry: true
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1}-public_registry --force --profile OIDC-User
+      #     platform: linux/arm64,linux/amd64
+      #     filters: *filters
+      #     requires: [pre-integration]
+      # - aws-ecr/build_and_push_image:
+      #     pre-steps:
+      #       - run:
+      #           name: "Export NPM_TOKEN"
+      #           command: echo 'export NPM_TOKEN="00000000-0000-0000-0000-000000000000"' >> "$BASH_ENV"
+      #     name: integration-tests-named-profile
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #           profile_name: "OIDC-User"
+      #     attach_workspace: true
+      #     region: "us-west-2"
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     workspace_root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+      #     create_repo: true
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra_build_args: '--build-arg NPM_TOKEN=${NPM_TOKEN} --build-arg=${CIRCLE_SHA1:0:7}'
+      #     set_repo_policy: true
+      #     repo_policy_path: ./sample/repo-policy.json
+      #     executor: amd64
+      #     filters: *filters
+      #     requires: [pre-integration]
+      # - tag-ecr-image:
+      #     name: integration-tests-tag-existing-image
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #           profile_name: "OIDC-User"
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+      #     region: "us-west-2"
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     source_tag: integration
+      #     target_tag: latest
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-named-profile --force --profile OIDC-User
+      #     filters: *filters
+      #     requires:
+      #       - integration-tests-named-profile
+      # - aws-ecr/build_and_push_image:
+      #     name: integration-tests-skip_when_tags_exist-populate-image-<<matrix.executor>>
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #           profile_name: "OIDC-User"
+      #     attach_workspace: true
+      #     region: "us-west-2"
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     workspace_root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
+      #     create_repo: true
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra_build_args: --compress
+      #     skip_when_tags_exist: true
+      #     matrix:
+      #       parameters:
+      #         executor: ["amd64", "arm64"]
+      #     filters: *filters
+      #     requires: [pre-integration]
+      # - aws-ecr/build_and_push_image:
+      #     name: integration-tests-skip_when_tags_exist-<<matrix.executor>>
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #           profile_name: "OIDC-User"
+      #     attach_workspace: true
+      #     region: "us-west-2"
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     workspace_root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra_build_args: --compress
+      #     skip_when_tags_exist: true
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: |
+      #             aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
+      #     matrix:
+      #       parameters:
+      #         executor: ["amd64", "arm64"]
+      #     filters: *filters
+      #     requires:
+      #       - integration-tests-skip_when_tags_exist-populate-image-amd64
+      #       - integration-tests-skip_when_tags_exist-populate-image-arm64
+      # - orb-tools/lint:
+      #     filters: *filters
+      # - orb-tools/pack:
+      #     filters: *filters
+      # - orb-tools/review:
+      #     filters: *release-filters
+      # - orb-tools/publish:
+      #     orb_name: circleci/aws-ecr
+      #     vcs_type: << pipeline.project.type >>
+      #     pub_type: production
+      #     enable_pr_comment: true
+      #     requires: [ orb-tools/lint, orb-tools/review, orb-tools/pack, integration-tests-default-profile, integration-tests-pubic-registry, integration-tests-skip_when_tags_exist-amd64, integration-tests-skip_when_tags_exist-arm64, integration-tests-named-profile, integration-tests-tag-existing-image ]
+      #     github_token: GHI_TOKEN
+      #     context: orb-publisher
+      #     filters: *release-filters
 executors:
   amd64:
     machine:

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -23,14 +23,14 @@ if [ -z "${!ORB_ENV_REGISTRY_ID}" ]; then
   exit 1
 fi
 
-if [ "${ORB_BOOL_PUBLIC_REGISTRY}" == "1" ]; then
+if [ "${ORB_BOOL_PUBLIC_REGISTRY}" -eq "1" ]; then
   ECR_COMMAND="ecr-public"
   ORB_VAL_ACCOUNT_URL="public.ecr.aws/${ORB_STR_PUBLIC_REGISTRY_ALIAS}"
 fi
 
 IFS="," read -ra DOCKER_TAGS <<<"${ORB_STR_TAG}"
 for tag in "${DOCKER_TAGS[@]}"; do
-  if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" = "1" ] || [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" = "true" ]; then
+  if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "1" ] || [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" = "true" ]; then
     docker_tag_exists_in_ecr=$(aws "${ECR_COMMAND}" describe-images --profile "${ORB_STR_PROFILE_NAME}" --registry-id "${!ORB_ENV_REGISTRY_ID}" --region "${ORB_STR_REGION}" --repository-name "${ORB_STR_REPO}" --query "contains(imageDetails[].imageTags[], '${tag}')")
     if [ "${docker_tag_exists_in_ecr}" = "true" ]; then
       docker pull "${ORB_VAL_ACCOUNT_URL}/${ORB_STR_REPO}:${tag}"
@@ -40,8 +40,8 @@ for tag in "${DOCKER_TAGS[@]}"; do
   docker_tag_args="${docker_tag_args} -t ${ORB_VAL_ACCOUNT_URL}/${ORB_STR_REPO}:${tag}"
 done
 
-if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" = "1" && ${number_of_tags_in_ecr} -lt ${#DOCKER_TAGS[@]} ]]; then
-  if [ "${ORB_BOOL_PUSH_IMAGE}" == "1" ]; then
+if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "0" ] || [[ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "1" && ${number_of_tags_in_ecr} -lt ${#DOCKER_TAGS[@]} ]]; then
+  if [ "${ORB_BOOL_PUSH_IMAGE}" -eq "1" ]; then
     set -- "$@" --push
 
     if [ -n "${ORB_STR_LIFECYCLE_POLICY_PATH}" ]; then
@@ -50,7 +50,7 @@ if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" = "0" ] || [[ "${ORB_BOOL_SKIP_WHEN_TAGS
         --lifecycle-policy-text "file://${ORB_STR_LIFECYCLE_POLICY_PATH}"
     fi
 
-  else
+  elif [ "${ORB_BOOL_PUSH_IMAGE}" -eq "0" ] && [ "${number_of_platforms}" -lt 1 ];then
     set -- "$@" --load
   fi
 


### PR DESCRIPTION
Due to a limitation with `docker buildx` found [here](https://github.com/docker/buildx/issues/59#issuecomment-616061869), users get the following error when trying to build an image with multiple platforms without pushing it: 

```
error: docker exporter does not currently support exporting manifest lists
``` 

Currently, when a user sets the `push_image` parameter to `false`, the `--load` flag is automatically applied to the `docker buildx` command. 

The `--load` flag is a shorthand for the combination of `--output=type=docker` and `--push=false` flags. It it instructs Docker Buildx to build the image and store it directly in the local Docker daemon without pushing it to a registry. This allows users to use the image immediately on their local machine without the need to push it to a remote registry.

However, the `--load` flag is not supported with multi-platform builds, resulting in the error above. To fix this issue, the `--load` is only set when `push_image` is set to `false` and the number of platforms is one. 