### PR TITLE
test: create test for building testing and pushing image

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -49,143 +49,215 @@ jobs:
           repo: <<parameters.repo>>
           source_tag: <<parameters.source_tag>>
           target_tag: <<parameters.target_tag>>
+  build-test-then-push-with-buildx:
+    machine:
+      image: ubuntu-2204:2022.07.1
+    parameters:
+      auth:
+        type: steps
+      attach_workspace:
+        type: boolean
+      workspace_root:
+        type: string
+      repo:
+        type: string
+      create_repo:
+        type: boolean
+      tag:
+        type: string
+      dockerfile:
+        type: string
+      path:
+        type: string
+      push_image:
+        type: boolean
+      platform:
+        type: string
+      region:
+        type: string
+    steps:
+      - aws-ecr/build_and_push_image:
+          auth: << parameters.auth >>
+          attach_workspace: << parameters.attach_workspace >>
+          workspace_root: << parameters.workspace_root >>
+          repo: << parameters.repo >>
+          create_repo: << parameters.create_repo >>
+          tag: << parameters.tag >>
+          dockerfile: << parameters.dockerfile >>
+          path: << parameters.path >>
+          platform: << parameters.platform >>
+          push_image: << parameters.push_image >>
+      - run:
+          name: Tests for docker image
+          command: |
+            set -x
+            docker image ls
+            docker run 122211685980.dkr.ecr.us-west-2.amazonaws.com/<< parameters.repo >>:<< parameters.tag >> ping -V
+            status=$(echo "$?")
+            if [ "${status}" != "0" ]; then exit 1; else exit 0; fi
+            set +x
+      - aws-ecr/push_image:
+          repo: << parameters.repo >>
+          region: << parameters.region >>
+          tag: << parameters.tag >>
 workflows:
   test-deploy:
     jobs:
       - pre-integration-checkout-workspace-job:
           name: pre-integration
           filters: *filters
-      - aws-ecr/build_and_push_image:
-          name: integration-test-multi-platform-without-push
+      - build-test-then-push-with-buildx:
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           attach_workspace: true
           workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-multi-platform-without-push
+          repo: aws-ecr-orb-${CIRCLE_SHA1}-build-test-then-push-with-buildx
           create_repo: true
           context: [CPE-OIDC]
-          tag: integration,myECRRepoTag
+          tag: alpha
           dockerfile: sample/Dockerfile
           path: workspace
-          executor: amd64
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1}-multi-platform-without-push --force
           push_image: false
-          platform: linux/amd64,linux/arm64
-          filters: *filters
-          requires: [pre-integration]
-      - aws-ecr/build_and_push_image:
-          name: integration-test-default-profile
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          attach_workspace: true
-          workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
-          create_repo: true
-          context: [CPE-OIDC]
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra_build_args: --compress
-          executor: amd64
-          lifecycle_policy_path: ./sample/lifecycle-policy.json
+          platform: linux/amd64
+          region: us-west-2
           post-steps:
             - run:
                 name: "Delete repository"
-                command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1}-default-profile --force
-          platform: linux/amd64,linux/arm64
+                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-build-test-then-push-with-buildx --region us-west-2 --force
           filters: *filters
           requires: [pre-integration]
-      - aws-ecr/build_and_push_image:
-          name: integration-test-pubic-registry
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
-          attach_workspace: true
-          workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public_registry
-          create_repo: true
-          region: "us-west-2"
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          tag: integration,myECRRepoTag
-          dockerfile: Dockerfile
-          path: ./sample
-          extra_build_args: --compress
-          executor: arm64
-          public_registry: true
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1}-public_registry --force --profile OIDC-User
-          platform: linux/arm64,linux/amd64
-          filters: *filters
-          requires: [pre-integration]
-      - aws-ecr/build_and_push_image:
-          pre-steps:
-            - run:
-                name: "Export NPM_TOKEN"
-                command: echo 'export NPM_TOKEN="00000000-0000-0000-0000-000000000000"' >> "$BASH_ENV"
-          name: integration-test-named-profile
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
-          attach_workspace: true
-          region: "us-west-2"
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-          create_repo: true
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra_build_args: '--build-arg NPM_TOKEN=${NPM_TOKEN} --build-arg=${CIRCLE_SHA1:0:7}'
-          set_repo_policy: true
-          repo_policy_path: ./sample/repo-policy.json
-          executor: amd64
-          filters: *filters
-          requires: [pre-integration]
-      - tag-ecr-image:
-          name: integration-test-tag-existing-image
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-          region: "us-west-2"
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          source_tag: integration
-          target_tag: latest
-          requires:
-            - integration-test-named-profile
-      - tag-ecr-image:
-          name: integration-test-tag-image-with-existing-tag
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-          region: "us-west-2"
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          source_tag: integration
-          target_tag: alpha,latest
-          skip_when_tags_exist: true
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-named-profile --force --profile OIDC-User
-          filters: *filters
-          requires:
-            - integration-test-tag-existing-image
+      # - aws-ecr/build_and_push_image:
+      #     name: integration-test-multi-platform-without-push
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     attach_workspace: true
+      #     workspace_root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-multi-platform-without-push
+      #     create_repo: true
+      #     context: [CPE-OIDC]
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     executor: amd64
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-multi-platform-without-push --region us-west-2 --force
+      #     push_image: false
+      #     platform: linux/amd64,linux/arm64
+      #     filters: *filters
+      #     requires: [pre-integration]
+      # - aws-ecr/build_and_push_image:
+      #     name: integration-test-default-profile
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     attach_workspace: true
+      #     workspace_root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
+      #     create_repo: true
+      #     context: [CPE-OIDC]
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra_build_args: --compress
+      #     executor: amd64
+      #     lifecycle_policy_path: ./sample/lifecycle-policy.json
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1}-default-profile --force
+      #     platform: linux/amd64,linux/arm64
+      #     filters: *filters
+      #     requires: [pre-integration]
+      # - aws-ecr/build_and_push_image:
+      #     name: integration-test-pubic-registry
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #           profile_name: "OIDC-User"
+      #     attach_workspace: true
+      #     workspace_root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public_registry
+      #     create_repo: true
+      #     region: "us-west-2"
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: Dockerfile
+      #     path: ./sample
+      #     extra_build_args: --compress
+      #     executor: arm64
+      #     public_registry: true
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1}-public_registry --force --profile OIDC-User
+      #     platform: linux/arm64,linux/amd64
+      #     filters: *filters
+      #     requires: [pre-integration]
+      # - aws-ecr/build_and_push_image:
+      #     pre-steps:
+      #       - run:
+      #           name: "Export NPM_TOKEN"
+      #           command: echo 'export NPM_TOKEN="00000000-0000-0000-0000-000000000000"' >> "$BASH_ENV"
+      #     name: integration-test-named-profile
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #           profile_name: "OIDC-User"
+      #     attach_workspace: true
+      #     region: "us-west-2"
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     workspace_root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+      #     create_repo: true
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra_build_args: '--build-arg NPM_TOKEN=${NPM_TOKEN} --build-arg=${CIRCLE_SHA1:0:7}'
+      #     set_repo_policy: true
+      #     repo_policy_path: ./sample/repo-policy.json
+      #     executor: amd64
+      #     filters: *filters
+      #     requires: [pre-integration]
+      # - tag-ecr-image:
+      #     name: integration-test-tag-existing-image
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #           profile_name: "OIDC-User"
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+      #     region: "us-west-2"
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     source_tag: integration
+      #     target_tag: latest
+      #     requires:
+      #       - integration-test-named-profile
+      # - tag-ecr-image:
+      #     name: integration-test-tag-image-with-existing-tag
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #           profile_name: "OIDC-User"
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+      #     region: "us-west-2"
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     source_tag: integration
+      #     target_tag: alpha,latest
+      #     skip_when_tags_exist: true
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-named-profile --force --profile OIDC-User
+      #     filters: *filters
+      #     requires:
+      #       - integration-test-tag-existing-image
       - aws-ecr/build_and_push_image:
           name: integration-test-skip_when_tags_exist-populate-image-<<matrix.executor>>
           auth:
@@ -200,59 +272,83 @@ workflows:
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
           create_repo: true
           tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
+          dockerfile: Dockerfile
+          path: ./sample
+          platform: linux/amd64,linux/arm64
           extra_build_args: --compress
           skip_when_tags_exist: true
           matrix:
             parameters:
-              executor: ["amd64", "arm64"]
+              executor: ["arm64", "amd64"]
           filters: *filters
           requires: [pre-integration]
-      - aws-ecr/build_and_push_image:
-          name: integration-test-skip_when_tags_exist-<<matrix.executor>>
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
-          attach_workspace: true
-          region: "us-west-2"
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra_build_args: --compress
-          skip_when_tags_exist: true
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: |
-                  aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
-          matrix:
-            parameters:
-              executor: ["amd64", "arm64"]
-          filters: *filters
-          requires:
-            - integration-test-skip_when_tags_exist-populate-image-amd64
-            - integration-test-skip_when_tags_exist-populate-image-arm64
-      - orb-tools/lint:
-          filters: *filters
-      - orb-tools/pack:
-          filters: *filters
-      - orb-tools/review:
-          filters: *release-filters
-      - orb-tools/publish:
-          orb_name: circleci/aws-ecr
-          vcs_type: << pipeline.project.type >>
-          pub_type: production
-          enable_pr_comment: true
-          requires: [ orb-tools/lint, orb-tools/review, orb-tools/pack, integration-test-default-profile, integration-test-pubic-registry, integration-test-skip_when_tags_exist-amd64, integration-test-skip_when_tags_exist-arm64, integration-test-named-profile, integration-test-tag-existing-image, integration-test-tag-image-with-existing-tag ]
-          github_token: GHI_TOKEN
-          context: orb-publisher
-          filters: *release-filters
+      # - aws-ecr/build_and_push_image:
+      #     name: integration-test-skip_when_tags_exist-populate-image-<<matrix.executor>>
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #           profile_name: "OIDC-User"
+      #     attach_workspace: true
+      #     region: "us-west-2"
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     workspace_root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
+      #     create_repo: true
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra_build_args: --compress
+      #     skip_when_tags_exist: true
+      #     matrix:
+      #       parameters:
+      #         executor: ["amd64", "arm64"]
+      #     filters: *filters
+      #     requires: [pre-integration]
+      # - aws-ecr/build_and_push_image:
+      #     name: integration-test-skip_when_tags_exist-<<matrix.executor>>
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #           profile_name: "OIDC-User"
+      #     attach_workspace: true
+      #     region: "us-west-2"
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     workspace_root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra_build_args: --compress
+      #     skip_when_tags_exist: true
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: |
+      #             aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
+      #     matrix:
+      #       parameters:
+      #         executor: ["amd64", "arm64"]
+      #     filters: *filters
+      #     requires:
+      #       - integration-test-skip_when_tags_exist-populate-image-amd64
+      #       - integration-test-skip_when_tags_exist-populate-image-arm64
+      # - orb-tools/lint:
+      #     filters: *filters
+      # - orb-tools/pack:
+      #     filters: *filters
+      # - orb-tools/review:
+      #     filters: *release-filters
+      # - orb-tools/publish:
+      #     orb_name: circleci/aws-ecr
+      #     vcs_type: << pipeline.project.type >>
+      #     pub_type: production
+      #     enable_pr_comment: true
+      #     requires: [ orb-tools/lint, orb-tools/review, orb-tools/pack, integration-test-default-profile, integration-test-pubic-registry, integration-test-skip_when_tags_exist-amd64, integration-test-skip_when_tags_exist-arm64, integration-test-named-profile, integration-test-tag-existing-image, integration-test-tag-image-with-existing-tag ]
+      #     github_token: GHI_TOKEN
+      #     context: orb-publisher
+      #     filters: *release-filters
 executors:
   amd64:
     machine:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -127,137 +127,137 @@ workflows:
                 command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-build-test-then-push-with-buildx --region us-west-2 --force
           filters: *filters
           requires: [pre-integration]
-      # - aws-ecr/build_and_push_image:
-      #     name: integration-test-multi-platform-without-push
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     attach_workspace: true
-      #     workspace_root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-multi-platform-without-push
-      #     create_repo: true
-      #     context: [CPE-OIDC]
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     executor: amd64
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-multi-platform-without-push --region us-west-2 --force
-      #     push_image: false
-      #     platform: linux/amd64,linux/arm64
-      #     filters: *filters
-      #     requires: [pre-integration]
-      # - aws-ecr/build_and_push_image:
-      #     name: integration-test-default-profile
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     attach_workspace: true
-      #     workspace_root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
-      #     create_repo: true
-      #     context: [CPE-OIDC]
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     extra_build_args: --compress
-      #     executor: amd64
-      #     lifecycle_policy_path: ./sample/lifecycle-policy.json
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1}-default-profile --force
-      #     platform: linux/amd64,linux/arm64
-      #     filters: *filters
-      #     requires: [pre-integration]
-      # - aws-ecr/build_and_push_image:
-      #     name: integration-test-pubic-registry
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #           profile_name: "OIDC-User"
-      #     attach_workspace: true
-      #     workspace_root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public_registry
-      #     create_repo: true
-      #     region: "us-west-2"
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: Dockerfile
-      #     path: ./sample
-      #     extra_build_args: --compress
-      #     executor: arm64
-      #     public_registry: true
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1}-public_registry --force --profile OIDC-User
-      #     platform: linux/arm64,linux/amd64
-      #     filters: *filters
-      #     requires: [pre-integration]
-      # - aws-ecr/build_and_push_image:
-      #     pre-steps:
-      #       - run:
-      #           name: "Export NPM_TOKEN"
-      #           command: echo 'export NPM_TOKEN="00000000-0000-0000-0000-000000000000"' >> "$BASH_ENV"
-      #     name: integration-test-named-profile
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #           profile_name: "OIDC-User"
-      #     attach_workspace: true
-      #     region: "us-west-2"
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     workspace_root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-      #     create_repo: true
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     extra_build_args: '--build-arg NPM_TOKEN=${NPM_TOKEN} --build-arg=${CIRCLE_SHA1:0:7}'
-      #     set_repo_policy: true
-      #     repo_policy_path: ./sample/repo-policy.json
-      #     executor: amd64
-      #     filters: *filters
-      #     requires: [pre-integration]
-      # - tag-ecr-image:
-      #     name: integration-test-tag-existing-image
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #           profile_name: "OIDC-User"
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-      #     region: "us-west-2"
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     source_tag: integration
-      #     target_tag: latest
-      #     requires:
-      #       - integration-test-named-profile
-      # - tag-ecr-image:
-      #     name: integration-test-tag-image-with-existing-tag
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #           profile_name: "OIDC-User"
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-      #     region: "us-west-2"
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     source_tag: integration
-      #     target_tag: alpha,latest
-      #     skip_when_tags_exist: true
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-named-profile --force --profile OIDC-User
-      #     filters: *filters
-      #     requires:
-      #       - integration-test-tag-existing-image
+      - aws-ecr/build_and_push_image:
+          name: integration-test-multi-platform-without-push
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          attach_workspace: true
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-multi-platform-without-push
+          create_repo: true
+          context: [CPE-OIDC]
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          executor: amd64
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-multi-platform-without-push --region us-west-2 --force
+          push_image: false
+          platform: linux/amd64,linux/arm64
+          filters: *filters
+          requires: [pre-integration]
+      - aws-ecr/build_and_push_image:
+          name: integration-test-default-profile
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          attach_workspace: true
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
+          create_repo: true
+          context: [CPE-OIDC]
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra_build_args: --compress
+          executor: amd64
+          lifecycle_policy_path: ./sample/lifecycle-policy.json
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1}-default-profile --force
+          platform: linux/amd64,linux/arm64
+          filters: *filters
+          requires: [pre-integration]
+      - aws-ecr/build_and_push_image:
+          name: integration-test-pubic-registry
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "OIDC-User"
+          attach_workspace: true
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public_registry
+          create_repo: true
+          region: "us-west-2"
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          tag: integration,myECRRepoTag
+          dockerfile: Dockerfile
+          path: ./sample
+          extra_build_args: --compress
+          executor: arm64
+          public_registry: true
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1}-public_registry --force --profile OIDC-User
+          platform: linux/arm64,linux/amd64
+          filters: *filters
+          requires: [pre-integration]
+      - aws-ecr/build_and_push_image:
+          pre-steps:
+            - run:
+                name: "Export NPM_TOKEN"
+                command: echo 'export NPM_TOKEN="00000000-0000-0000-0000-000000000000"' >> "$BASH_ENV"
+          name: integration-test-named-profile
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "OIDC-User"
+          attach_workspace: true
+          region: "us-west-2"
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+          create_repo: true
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra_build_args: '--build-arg NPM_TOKEN=${NPM_TOKEN} --build-arg=${CIRCLE_SHA1:0:7}'
+          set_repo_policy: true
+          repo_policy_path: ./sample/repo-policy.json
+          executor: amd64
+          filters: *filters
+          requires: [pre-integration]
+      - tag-ecr-image:
+          name: integration-test-tag-existing-image
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "OIDC-User"
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+          region: "us-west-2"
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          source_tag: integration
+          target_tag: latest
+          requires:
+            - integration-test-named-profile
+      - tag-ecr-image:
+          name: integration-test-tag-image-with-existing-tag
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "OIDC-User"
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+          region: "us-west-2"
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          source_tag: integration
+          target_tag: alpha,latest
+          skip_when_tags_exist: true
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-named-profile --force --profile OIDC-User
+          filters: *filters
+          requires:
+            - integration-test-tag-existing-image
       - aws-ecr/build_and_push_image:
           name: integration-test-skip_when_tags_exist-populate-image-<<matrix.executor>>
           auth:
@@ -282,73 +282,73 @@ workflows:
               executor: ["arm64", "amd64"]
           filters: *filters
           requires: [pre-integration]
-      # - aws-ecr/build_and_push_image:
-      #     name: integration-test-skip_when_tags_exist-populate-image-<<matrix.executor>>
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #           profile_name: "OIDC-User"
-      #     attach_workspace: true
-      #     region: "us-west-2"
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     workspace_root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
-      #     create_repo: true
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     extra_build_args: --compress
-      #     skip_when_tags_exist: true
-      #     matrix:
-      #       parameters:
-      #         executor: ["amd64", "arm64"]
-      #     filters: *filters
-      #     requires: [pre-integration]
-      # - aws-ecr/build_and_push_image:
-      #     name: integration-test-skip_when_tags_exist-<<matrix.executor>>
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #           profile_name: "OIDC-User"
-      #     attach_workspace: true
-      #     region: "us-west-2"
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     workspace_root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     extra_build_args: --compress
-      #     skip_when_tags_exist: true
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: |
-      #             aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
-      #     matrix:
-      #       parameters:
-      #         executor: ["amd64", "arm64"]
-      #     filters: *filters
-      #     requires:
-      #       - integration-test-skip_when_tags_exist-populate-image-amd64
-      #       - integration-test-skip_when_tags_exist-populate-image-arm64
-      # - orb-tools/lint:
-      #     filters: *filters
-      # - orb-tools/pack:
-      #     filters: *filters
-      # - orb-tools/review:
-      #     filters: *release-filters
-      # - orb-tools/publish:
-      #     orb_name: circleci/aws-ecr
-      #     vcs_type: << pipeline.project.type >>
-      #     pub_type: production
-      #     enable_pr_comment: true
-      #     requires: [ orb-tools/lint, orb-tools/review, orb-tools/pack, integration-test-default-profile, integration-test-pubic-registry, integration-test-skip_when_tags_exist-amd64, integration-test-skip_when_tags_exist-arm64, integration-test-named-profile, integration-test-tag-existing-image, integration-test-tag-image-with-existing-tag ]
-      #     github_token: GHI_TOKEN
-      #     context: orb-publisher
-      #     filters: *release-filters
+      - aws-ecr/build_and_push_image:
+          name: integration-test-skip_when_tags_exist-populate-image-<<matrix.executor>>
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "OIDC-User"
+          attach_workspace: true
+          region: "us-west-2"
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
+          create_repo: true
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra_build_args: --compress
+          skip_when_tags_exist: true
+          matrix:
+            parameters:
+              executor: ["amd64", "arm64"]
+          filters: *filters
+          requires: [pre-integration]
+      - aws-ecr/build_and_push_image:
+          name: integration-test-skip_when_tags_exist-<<matrix.executor>>
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "OIDC-User"
+          attach_workspace: true
+          region: "us-west-2"
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra_build_args: --compress
+          skip_when_tags_exist: true
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: |
+                  aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
+          matrix:
+            parameters:
+              executor: ["amd64", "arm64"]
+          filters: *filters
+          requires:
+            - integration-test-skip_when_tags_exist-populate-image-amd64
+            - integration-test-skip_when_tags_exist-populate-image-arm64
+      - orb-tools/lint:
+          filters: *filters
+      - orb-tools/pack:
+          filters: *filters
+      - orb-tools/review:
+          filters: *release-filters
+      - orb-tools/publish:
+          orb_name: circleci/aws-ecr
+          vcs_type: << pipeline.project.type >>
+          pub_type: production
+          enable_pr_comment: true
+          requires: [ orb-tools/lint, orb-tools/review, orb-tools/pack, integration-test-default-profile, integration-test-pubic-registry, integration-test-skip_when_tags_exist-amd64, integration-test-skip_when_tags_exist-arm64, integration-test-named-profile, integration-test-tag-existing-image, integration-test-tag-image-with-existing-tag ]
+          github_token: GHI_TOKEN
+          context: orb-publisher
+          filters: *release-filters
 executors:
   amd64:
     machine:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -93,8 +93,8 @@ jobs:
             set -x
             docker image ls
             docker run 122211685980.dkr.ecr.us-west-2.amazonaws.com/<< parameters.repo >>:<< parameters.tag >> ping -V
-            status=$(echo "$?")
-            if [ "${status}" != "0" ]; then exit 1; else exit 0; fi
+            status=$?
+            if [ "${status}" -ne 0 ]; then exit "${status}"; else exit 0; fi
             set +x
       - aws-ecr/push_image:
           repo: << parameters.repo >>

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -283,29 +283,6 @@ workflows:
           filters: *filters
           requires: [pre-integration]
       - aws-ecr/build_and_push_image:
-          name: integration-test-skip_when_tags_exist-populate-image-<<matrix.executor>>
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
-          attach_workspace: true
-          region: "us-west-2"
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
-          create_repo: true
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra_build_args: --compress
-          skip_when_tags_exist: true
-          matrix:
-            parameters:
-              executor: ["amd64", "arm64"]
-          filters: *filters
-          requires: [pre-integration]
-      - aws-ecr/build_and_push_image:
           name: integration-test-skip_when_tags_exist-<<matrix.executor>>
           auth:
             - aws-cli/setup:

--- a/sample/Dockerfile
+++ b/sample/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:latest
+FROM cimg/base:current
 
-RUN apk update
-RUN apk upgrade
-RUN apk add curl 
+CMD ["bin/bash"]
+RUN sudo apt-get update && sudo apt-get install -y iputils-ping
+
 

--- a/sample/Dockerfile
+++ b/sample/Dockerfile
@@ -1,7 +1,6 @@
-FROM cimg/node:current
+FROM alpine:latest
 
-WORKDIR /app
-ADD . /app
-EXPOSE 80
+RUN apk update
+RUN apk upgrade
+RUN apk add curl 
 
-ENTRYPOINT ["npm", "start"]

--- a/src/examples/build_test_then_push_image.yml
+++ b/src/examples/build_test_then_push_image.yml
@@ -1,0 +1,85 @@
+description: >
+  This is an example of a job that builds a docker image with docker buildx, tests
+  the image and then pushes it to the specified ECR repository.
+
+usage:
+  version: 2.1
+
+  orbs:
+    aws-ecr: circleci/aws-ecr@9.0
+    # Importing aws-cli orb is required
+    aws-cli: circleci/aws-cli@4.0
+  jobs:
+    build-test-then-push-with-buildx:
+      machine:
+        image: ubuntu-2204:2022.07.1
+      parameters:
+        auth:
+          type: steps
+        attach_workspace:
+          type: boolean
+        workspace_root:
+          type: string
+        repo:
+          type: string
+        create_repo:
+          type: boolean
+        tag:
+          type: string
+        dockerfile:
+          type: string
+        path:
+          type: string
+        push_image:
+          type: boolean
+        platform:
+          type: string
+        region:
+          type: string
+      steps:
+        # build docker image
+        - aws-ecr/build_and_push_image:
+            auth: << parameters.auth >>
+            attach_workspace: << parameters.attach_workspace >>
+            workspace_root: << parameters.workspace_root >>
+            repo: << parameters.repo >>
+            create_repo: << parameters.create_repo >>
+            tag: << parameters.tag >>
+            dockerfile: << parameters.dockerfile >>
+            path: << parameters.path >>
+            platform: << parameters.platform >>
+            push_image: << parameters.push_image >>
+        - run:
+            name: Tests for docker image
+            # run a test command that's present in the docker image
+            command: |
+              set -x
+              docker run 123456789012.dkr.ecr.us-west-2.amazonaws.com/<< parameters.repo >>:<< parameters.tag >> ping -V
+              status=$(echo "$?")
+              if [ "${status}" != "0" ]; then exit 1; else exit 0; fi
+              set +x
+        # push image to ecr
+        - aws-ecr/push_image:
+            repo: << parameters.repo >>
+            region: << parameters.region >>
+            tag: << parameters.tag >>
+workflows:
+  build-image-test-image-push-image-with-buildx:
+    jobs:
+      - build-test-then-push-with-buildx:
+          context: CircleCI_OIDC_Token
+          # authenticate job using aws-cli/setup command
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::123456789012
+          repo: my-sample-repo
+          attach_workspace: true
+          workspace_root: .
+          create_repo: true
+          tag: alpha
+          dockerfile: Dockerfile
+          path: workspace
+          push_image: false
+          platform: linux/amd64
+          region: us-west-2
+          requires: [pre-integration]

--- a/src/examples/build_test_then_push_image.yml
+++ b/src/examples/build_test_then_push_image.yml
@@ -1,54 +1,39 @@
 description: >
-  This is an example of a job that builds a docker image with docker buildx, tests
-  the image and then pushes it to the specified ECR repository.
+  This is an example of a job that builds a docker image with docker buildx. It tests
+  the image and before pushing it to the specified ECR repository. 
+  NOTE: The push_image parameter must be set to false. Only one platform can be specified and
+  loaded into the local Docker Daemon. Loading multi-architecture images is not supported at this time. 
 
 usage:
   version: 2.1
 
   orbs:
     aws-ecr: circleci/aws-ecr@9.0
-    # Importing aws-cli orb is required
+    # importing aws-cli orb is required
     aws-cli: circleci/aws-cli@4.0
   jobs:
     build-test-then-push-with-buildx:
       machine:
         image: ubuntu-2204:2022.07.1
-      parameters:
-        auth:
-          type: steps
-        attach_workspace:
-          type: boolean
-        workspace_root:
-          type: string
-        repo:
-          type: string
-        create_repo:
-          type: boolean
-        tag:
-          type: string
-        dockerfile:
-          type: string
-        path:
-          type: string
-        push_image:
-          type: boolean
-        platform:
-          type: string
-        region:
-          type: string
       steps:
         # build docker image
         - aws-ecr/build_and_push_image:
-            auth: << parameters.auth >>
-            attach_workspace: << parameters.attach_workspace >>
-            workspace_root: << parameters.workspace_root >>
-            repo: << parameters.repo >>
-            create_repo: << parameters.create_repo >>
-            tag: << parameters.tag >>
-            dockerfile: << parameters.dockerfile >>
-            path: << parameters.path >>
-            platform: << parameters.platform >>
-            push_image: << parameters.push_image >>
+            # authenticate job using aws-cli/setup command
+            auth:
+              - aws-cli/setup:
+                  role_arn: arn:aws:iam::123456789012
+            repo: my-sample-repo
+            create_repo: true
+            attach_workspace: true
+            workspace_root: .
+            tag: sampleTag
+            dockerfile: Dockerfile
+            path: workspace
+            # set to false to test image before pushing
+            push_image: false
+            # only one platform can be specified. Multi-platform is not supported.
+            platform: linux/amd64
+            region: us-west-2
         - run:
             name: Tests for docker image
             # run a test command that's present in the docker image
@@ -68,18 +53,3 @@ workflows:
     jobs:
       - build-test-then-push-with-buildx:
           context: CircleCI_OIDC_Token
-          # authenticate job using aws-cli/setup command
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::123456789012
-          repo: my-sample-repo
-          attach_workspace: true
-          workspace_root: .
-          create_repo: true
-          tag: alpha
-          dockerfile: Dockerfile
-          path: workspace
-          push_image: false
-          platform: linux/amd64
-          region: us-west-2
-          requires: [pre-integration]

--- a/src/examples/build_test_then_push_image.yml
+++ b/src/examples/build_test_then_push_image.yml
@@ -1,8 +1,8 @@
 description: >
   This is an example of a job that builds a docker image with docker buildx. It tests
-  the image and before pushing it to the specified ECR repository. 
+  the image and before pushing it to the specified ECR repository.
   NOTE: The push_image parameter must be set to false. Only one platform can be specified and
-  loaded into the local Docker Daemon. Loading multi-architecture images is not supported at this time. 
+  loaded into the local Docker Daemon. Loading multi-architecture images is not supported at this time.
 
 usage:
   version: 2.1

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -50,7 +50,7 @@ if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "0" ] || [[ "${ORB_BOOL_SKIP_WHEN_TA
         --lifecycle-policy-text "file://${ORB_STR_LIFECYCLE_POLICY_PATH}"
     fi
 
-  elif [ "${ORB_BOOL_PUSH_IMAGE}" -eq "0" ] && [ "${number_of_platforms}" -lt 1 ];then
+  elif [ "${ORB_BOOL_PUSH_IMAGE}" -eq "0" ] && [ "${number_of_platforms}" -le 1 ];then
     set -- "$@" --load
   fi
 


### PR DESCRIPTION
Currently, with `docker buildx`, users would like to build an image and test it before pushing it. With the `build_and_push_image` command, this is not obvious. 

This `PR` adds a test to `test-deploy.yml` and a usage example that shows users how do achieve this scenario. 