### PR TITLE
fix: --cache-to flag not working 

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -173,6 +173,21 @@ workflows:
           filters: *filters
           requires: [pre-integration]
       - aws-ecr/build_and_push_image:
+          name: integration-test-cache-to-flag
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          attach_workspace: true
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-cache-to-flag
+          context: [CPE-OIDC]
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra_build_args: --cache-to type=local,dest=/tmp
+          executor: amd64
+          filters: *filters
+          requires: [pre-integration]
+      - aws-ecr/build_and_push_image:
           name: integration-test-pubic-registry
           auth:
             - aws-cli/setup:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -184,6 +184,7 @@ workflows:
           dockerfile: sample/Dockerfile
           path: workspace
           extra_build_args: --cache-to type=local,dest=/tmp
+          push_image: false
           executor: amd64
           filters: *filters
           requires: [pre-integration]

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -233,7 +233,9 @@ workflows:
           tag: integration,myECRRepoTag
           dockerfile: sample/Dockerfile
           path: workspace
-          extra_build_args: '--build-arg NPM_TOKEN=${NPM_TOKEN} --build-arg=${CIRCLE_SHA1:0:7}'
+          extra_build_args: >-
+            --build-arg NPM_TOKEN=${NPM_TOKEN}
+            --build-arg=${CIRCLE_SHA1:0:7}
           set_repo_policy: true
           repo_policy_path: ./sample/repo-policy.json
           executor: amd64

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -67,7 +67,7 @@ if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "0" ] || [[ "${ORB_BOOL_SKIP_WHEN_TA
     fi
     context_args="--context builder"
   # if no builder instance is currently used, create one
-  elif ! docker buildx inspect | grep "default * docker"; then 
+  elif ! docker buildx inspect | grep -q "default * docker"; then 
     docker buildx create --use 
   fi 
 

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -66,6 +66,9 @@ if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "0" ] || [[ "${ORB_BOOL_SKIP_WHEN_TA
       docker --context builder buildx create --name DLC_builder --use
     fi
     context_args="--context builder"
+  # if no builder instance is currently used, create one
+  elif ! docker buildx inspect | grep "default * docker"; then 
+    docker buildx create --use 
   fi 
 
 set -x


### PR DESCRIPTION
When a user runs the `build_and_push_image` job with one specified platform in a `cimg` executor, the default docker `builder` is used. This is problematic because without using the `docker buildx builder`, some features like the `--cache-to` flag will not work. 

This `PR` checks the current `builder` using the `docker buildx inspect` command. If the `builder` is the `default`, `docker buildx create --use` will be run to set up a new builder to be used. 