### PR TITLE
refactor!: rename registry_id and change type

### DIFF
--- a/src/commands/build_and_push_image.yml
+++ b/src/commands/build_and_push_image.yml
@@ -3,9 +3,9 @@ description: >
   Log into Amazon ECR, build and push a Docker image to the specified repository.
   NOTE: Some commands may not work with AWS CLI Version 1.
 parameters:
-  registry_id:
-    type: env_var_name
-    default: AWS_ACCOUNT_ID
+  account_id:
+    type: string
+    default: ${AWS_ACCOUNT_ID}
     description: >
       The 12 digit AWS id associated with the ECR account.
       This field is required
@@ -228,7 +228,7 @@ steps:
   - ecr_login:
       profile_name: <<parameters.profile_name>>
       region: <<parameters.region>>
-      registry_id: <<parameters.registry_id>>
+      account_id: <<parameters.account_id>>
       public_registry: <<parameters.public_registry>>
   - when:
       condition: <<parameters.create_repo>>
@@ -255,7 +255,7 @@ steps:
       steps: <<parameters.registry_login>>
 
   - build_image:
-      registry_id: <<parameters.registry_id>>
+      account_id: <<parameters.account_id>>
       repo: <<parameters.repo>>
       tag: <<parameters.tag>>
       dockerfile: <<parameters.dockerfile>>

--- a/src/commands/build_image.yml
+++ b/src/commands/build_image.yml
@@ -3,9 +3,9 @@ description: >
   NOTE: Some commands may not work with AWS CLI Version 1.
 
 parameters:
-  registry_id:
-    type: env_var_name
-    default: AWS_ACCOUNT_ID
+  account_id:
+    type: string
+    default: ${AWS_ACCOUNT_ID}
     description: >
       The 12 digit AWS Registry ID associated with the ECR account.
       This field is required
@@ -116,7 +116,7 @@ steps:
         ORB_EVAL_PATH: <<parameters.path>>
         ORB_STR_DOCKERFILE: <<parameters.dockerfile>>
         ORB_STR_PROFILE_NAME: <<parameters.profile_name>>
-        ORB_ENV_REGISTRY_ID: <<parameters.registry_id>>
+        ORB_STR_ACCOUNT_ID: <<parameters.account_id>>
         ORB_STR_REGION: <<parameters.region>>
         ORB_STR_PLATFORM: <<parameters.platform>>
         ORB_BOOL_PUBLIC_REGISTRY: <<parameters.public_registry>>

--- a/src/commands/build_image.yml
+++ b/src/commands/build_image.yml
@@ -7,7 +7,7 @@ parameters:
     type: string
     default: ${AWS_ACCOUNT_ID}
     description: >
-      The 12 digit AWS Registry ID associated with the ECR account.
+      The 12 digit AWS Account ID associated with the ECR account.
       This field is required
 
   repo:

--- a/src/commands/ecr_login.yml
+++ b/src/commands/ecr_login.yml
@@ -3,9 +3,9 @@ description: >
   NOTE: Some commands may not work with AWS CLI Version 1.
 
 parameters:
-  registry_id:
-    type: env_var_name
-    default: AWS_ACCOUNT_ID
+  account_id:
+    type: string
+    default: ${AWS_ACCOUNT_ID}
     description: >
       The 12 digit AWS id associated with the ECR account.
       This field is required
@@ -38,7 +38,7 @@ steps:
       name: Log into Amazon ECR with profile <<parameters.profile_name>>
       environment:
         ORB_STR_PROFILE_NAME: <<parameters.profile_name>>
-        ORB_ENV_REGISTRY_ID: <<parameters.registry_id>>
+        ORB_STR_ACCOUNT_ID: <<parameters.account_id>>
         ORB_STR_REGION: <<parameters.region>>
         ORB_BOOL_PUBLIC_REGISTRY: <<parameters.public_registry>>
         ORB_STR_AWS_DOMAIN: <<parameters.aws_domain>>

--- a/src/commands/push_image.yml
+++ b/src/commands/push_image.yml
@@ -6,7 +6,7 @@ parameters:
     type: string
     default: ${AWS_ACCOUNT_ID}
     description: >
-      The 12 digit AWS Registry ID associated with the ECR account.
+      The 12 digit AWS Account ID associated with the ECR account.
       This field is required
   region:
     type: string

--- a/src/commands/push_image.yml
+++ b/src/commands/push_image.yml
@@ -2,9 +2,9 @@ description: >
   Install AWS CLI Version 2 and configure credentials if needed to push a container image to the Amazon ECR registry
   NOTE: Some commands may not work with AWS CLI Version 1.
 parameters:
-  registry_id:
-    type: env_var_name
-    default: AWS_ACCOUNT_ID
+  account_id:
+    type: string
+    default: ${AWS_ACCOUNT_ID}
     description: >
       The 12 digit AWS Registry ID associated with the ECR account.
       This field is required
@@ -44,6 +44,6 @@ steps:
         ORB_STR_TAG: << parameters.tag >>
         ORB_BOOL_PUBLIC_REGISTRY: <<parameters.public_registry>>
         ORB_STR_PUBLIC_REGISTRY_ALIAS: <<parameters.public_registry_alias>>
-        ORB_ENV_REGISTRY_ID: << parameters.registry_id >>
+        ORB_STR_ACCOUNT_ID: << parameters.account_id >>
         ORB_STR_AWS_DOMAIN: <<parameters.aws_domain>>
       command: << include(scripts/push_image.sh) >>

--- a/src/examples/simple_build_and_push.yml
+++ b/src/examples/simple_build_and_push.yml
@@ -44,8 +44,8 @@ usage:
             #Your AWS region
             region: ${AWS_DEFAULT_REGION}
 
-            # name of env var storing your ECR Registry ID
-            account_id: AWS_ACCOUNT_ID
+            # Your AWS account ID. use ${variable_name} if stored as an environment variable \
+            account_id: ${AWS_ACCOUNT_ID}
 
             # ECR image tags (comma separated string), defaults to "latest"
             tag: latest,myECRRepoTag

--- a/src/examples/simple_build_and_push.yml
+++ b/src/examples/simple_build_and_push.yml
@@ -45,7 +45,7 @@ usage:
             region: ${AWS_DEFAULT_REGION}
 
             # name of env var storing your ECR Registry ID
-            registry_id: AWS_ACCOUNT_ID
+            account_id: AWS_ACCOUNT_ID
 
             # ECR image tags (comma separated string), defaults to "latest"
             tag: latest,myECRRepoTag

--- a/src/jobs/build_and_push_image.yml
+++ b/src/jobs/build_and_push_image.yml
@@ -12,9 +12,9 @@ parameters:
     type: executor
     default: default
 
-  registry_id:
-    type: env_var_name
-    default: AWS_ACCOUNT_ID
+  account_id:
+    type: string
+    default: ${AWS_ACCOUNT_ID}
     description: >
       The 12 digit AWS id associated with the ECR account.
       This field is required
@@ -208,7 +208,7 @@ parameters:
 
 steps:
   - build_and_push_image:
-      registry_id: <<parameters.registry_id>>
+      account_id: <<parameters.account_id>>
       repo: <<parameters.repo>>
       tag: <<parameters.tag>>
       dockerfile: <<parameters.dockerfile>>

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -4,7 +4,7 @@ ORB_STR_REPO="$(circleci env subst "${ORB_STR_REPO}")"
 ORB_STR_TAG="$(circleci env subst "${ORB_STR_TAG}")"
 ORB_EVAL_PATH="$(eval echo "${ORB_EVAL_PATH}")"
 ORB_STR_AWS_DOMAIN="$(echo "${ORB_STR_AWS_DOMAIN}" | circleci env subst)"
-ORB_VAL_ACCOUNT_URL="${!ORB_ENV_REGISTRY_ID}.dkr.ecr.${ORB_STR_REGION}.${ORB_STR_AWS_DOMAIN}"
+ORB_VAL_ACCOUNT_URL="${!ORB_STR_ACCOUNT_ID}.dkr.ecr.${ORB_STR_REGION}.${ORB_STR_AWS_DOMAIN}"
 ORB_STR_PUBLIC_REGISTRY_ALIAS="$(circleci env subst "${ORB_STR_PUBLIC_REGISTRY_ALIAS}")"
 ORB_STR_EXTRA_BUILD_ARGS="$(echo "${ORB_STR_EXTRA_BUILD_ARGS}" | circleci env subst)"
 ORB_EVAL_BUILD_PATH="$(eval echo "${ORB_EVAL_BUILD_PATH}")"
@@ -19,7 +19,7 @@ number_of_tags_in_ecr=0
 IFS=', ' read -ra platform <<<"${ORB_STR_PLATFORM}"
 number_of_platforms="${#platform[@]}"
 
-if [ -z "${!ORB_ENV_REGISTRY_ID}" ]; then
+if [ -z "${!ORB_STR_ACCOUNT_ID}" ]; then
   echo "The registry ID is not found. Please add the registry ID as an environment variable in CicleCI before continuing."
   exit 1
 fi
@@ -32,7 +32,7 @@ fi
 IFS="," read -ra DOCKER_TAGS <<<"${ORB_STR_TAG}"
 for tag in "${DOCKER_TAGS[@]}"; do
   if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "1" ] || [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" = "true" ]; then
-    docker_tag_exists_in_ecr=$(aws "${ECR_COMMAND}" describe-images --profile "${ORB_STR_PROFILE_NAME}" --registry-id "${!ORB_ENV_REGISTRY_ID}" --region "${ORB_STR_REGION}" --repository-name "${ORB_STR_REPO}" --query "contains(imageDetails[].imageTags[], '${tag}')")
+    docker_tag_exists_in_ecr=$(aws "${ECR_COMMAND}" describe-images --profile "${ORB_STR_PROFILE_NAME}" --registry-id "${!ORB_STR_ACCOUNT_ID}" --region "${ORB_STR_REGION}" --repository-name "${ORB_STR_REPO}" --query "contains(imageDetails[].imageTags[], '${tag}')")
     if [ "${docker_tag_exists_in_ecr}" = "true" ]; then
       docker pull "${ORB_VAL_ACCOUNT_URL}/${ORB_STR_REPO}:${tag}"
       number_of_tags_in_ecr=$((number_of_tags_in_ecr += 1))

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -21,7 +21,7 @@ IFS=', ' read -ra platform <<<"${ORB_STR_PLATFORM}"
 number_of_platforms="${#platform[@]}"
 
 if [ -z "${ORB_STR_ACCOUNT_ID}" ]; then
-  echo "The registry ID is not found. Please add the registry ID as an environment variable in CicleCI before continuing."
+  echo "The account ID is not found. Please add the account ID before continuing."
   exit 1
 fi
 

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -4,7 +4,8 @@ ORB_STR_REPO="$(circleci env subst "${ORB_STR_REPO}")"
 ORB_STR_TAG="$(circleci env subst "${ORB_STR_TAG}")"
 ORB_EVAL_PATH="$(eval echo "${ORB_EVAL_PATH}")"
 ORB_STR_AWS_DOMAIN="$(echo "${ORB_STR_AWS_DOMAIN}" | circleci env subst)"
-ORB_VAL_ACCOUNT_URL="${!ORB_STR_ACCOUNT_ID}.dkr.ecr.${ORB_STR_REGION}.${ORB_STR_AWS_DOMAIN}"
+ORB_STR_ACCOUNT_ID="$(circleci env subst "${ORB_STR_ACCOUNT_ID}")"
+ORB_VAL_ACCOUNT_URL="${ORB_STR_ACCOUNT_ID}.dkr.ecr.${ORB_STR_REGION}.${ORB_STR_AWS_DOMAIN}"
 ORB_STR_PUBLIC_REGISTRY_ALIAS="$(circleci env subst "${ORB_STR_PUBLIC_REGISTRY_ALIAS}")"
 ORB_STR_EXTRA_BUILD_ARGS="$(echo "${ORB_STR_EXTRA_BUILD_ARGS}" | circleci env subst)"
 ORB_EVAL_BUILD_PATH="$(eval echo "${ORB_EVAL_BUILD_PATH}")"
@@ -19,7 +20,7 @@ number_of_tags_in_ecr=0
 IFS=', ' read -ra platform <<<"${ORB_STR_PLATFORM}"
 number_of_platforms="${#platform[@]}"
 
-if [ -z "${!ORB_STR_ACCOUNT_ID}" ]; then
+if [ -z "${ORB_STR_ACCOUNT_ID}" ]; then
   echo "The registry ID is not found. Please add the registry ID as an environment variable in CicleCI before continuing."
   exit 1
 fi
@@ -32,7 +33,7 @@ fi
 IFS="," read -ra DOCKER_TAGS <<<"${ORB_STR_TAG}"
 for tag in "${DOCKER_TAGS[@]}"; do
   if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "1" ] || [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" = "true" ]; then
-    docker_tag_exists_in_ecr=$(aws "${ECR_COMMAND}" describe-images --profile "${ORB_STR_PROFILE_NAME}" --registry-id "${!ORB_STR_ACCOUNT_ID}" --region "${ORB_STR_REGION}" --repository-name "${ORB_STR_REPO}" --query "contains(imageDetails[].imageTags[], '${tag}')")
+    docker_tag_exists_in_ecr=$(aws "${ECR_COMMAND}" describe-images --profile "${ORB_STR_PROFILE_NAME}" --registry-id "${ORB_STR_ACCOUNT_ID}" --region "${ORB_STR_REGION}" --repository-name "${ORB_STR_REPO}" --query "contains(imageDetails[].imageTags[], '${tag}')")
     if [ "${docker_tag_exists_in_ecr}" = "true" ]; then
       docker pull "${ORB_VAL_ACCOUNT_URL}/${ORB_STR_REPO}:${tag}"
       number_of_tags_in_ecr=$((number_of_tags_in_ecr += 1))

--- a/src/scripts/ecr_login.sh
+++ b/src/scripts/ecr_login.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 ORB_STR_REGION="$(circleci env subst "${ORB_STR_REGION}")"
 ORB_STR_PROFILE_NAME="$(circleci env subst "${ORB_STR_PROFILE_NAME}")"
-ORB_VAL_ACCOUNT_URL="${!ORB_STR_ACCOUNT_ID}.dkr.ecr.${ORB_STR_REGION}.${ORB_STR_AWS_DOMAIN}"
+ORB_STR_ACCOUNT_ID="$(circleci env subst "${ORB_STR_ACCOUNT_ID}")"
+ORB_VAL_ACCOUNT_URL="${ORB_STR_ACCOUNT_ID}.dkr.ecr.${ORB_STR_REGION}.${ORB_STR_AWS_DOMAIN}"
 ECR_COMMAND="ecr"
 
-if [ -z "${!ORB_STR_ACCOUNT_ID}" ]; then
+if [ -z "${ORB_STR_ACCOUNT_ID}" ]; then
   echo "The registry ID is not found. Please add the registry ID as an environment variable in CicleCI before continuing."
   exit 1
 fi

--- a/src/scripts/ecr_login.sh
+++ b/src/scripts/ecr_login.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 ORB_STR_REGION="$(circleci env subst "${ORB_STR_REGION}")"
 ORB_STR_PROFILE_NAME="$(circleci env subst "${ORB_STR_PROFILE_NAME}")"
-ORB_VAL_ACCOUNT_URL="${!ORB_ENV_REGISTRY_ID}.dkr.ecr.${ORB_STR_REGION}.${ORB_STR_AWS_DOMAIN}"
+ORB_VAL_ACCOUNT_URL="${!ORB_STR_ACCOUNT_ID}.dkr.ecr.${ORB_STR_REGION}.${ORB_STR_AWS_DOMAIN}"
 ECR_COMMAND="ecr"
 
-if [ -z "${!ORB_ENV_REGISTRY_ID}" ]; then
+if [ -z "${!ORB_STR_ACCOUNT_ID}" ]; then
   echo "The registry ID is not found. Please add the registry ID as an environment variable in CicleCI before continuing."
   exit 1
 fi

--- a/src/scripts/ecr_login.sh
+++ b/src/scripts/ecr_login.sh
@@ -6,7 +6,7 @@ ORB_VAL_ACCOUNT_URL="${ORB_STR_ACCOUNT_ID}.dkr.ecr.${ORB_STR_REGION}.${ORB_STR_A
 ECR_COMMAND="ecr"
 
 if [ -z "${ORB_STR_ACCOUNT_ID}" ]; then
-  echo "The registry ID is not found. Please add the registry ID as an environment variable in CicleCI before continuing."
+  echo "The account ID is not found. Please add the account ID before continuing."
   exit 1
 fi
 

--- a/src/scripts/push_image.sh
+++ b/src/scripts/push_image.sh
@@ -7,7 +7,7 @@ ORB_VAL_ACCOUNT_URL="${ORB_STR_ACCOUNT_ID}.dkr.ecr.${ORB_STR_REGION}.${ORB_STR_A
 ORB_STR_PUBLIC_REGISTRY_ALIAS="$(circleci env subst "${ORB_STR_PUBLIC_REGISTRY_ALIAS}")"
 
 if [ -z "${ORB_STR_ACCOUNT_ID}" ]; then
-  echo "The registry ID is not found. Please add the registry ID as an environment variable in CicleCI before continuing."
+  echo "The account ID is not found. Please add the account ID before continuing."
   exit 1
 fi
 

--- a/src/scripts/push_image.sh
+++ b/src/scripts/push_image.sh
@@ -2,10 +2,10 @@
 ORB_STR_REPO="$(circleci env subst "${ORB_STR_REPO}")"
 ORB_STR_TAG="$(circleci env subst "${ORB_STR_TAG}")"
 ORB_STR_REGION="$(circleci env subst "${ORB_STR_REGION}")"
-ORB_VAL_ACCOUNT_URL="${!ORB_ENV_REGISTRY_ID}.dkr.ecr.${ORB_STR_REGION}.${ORB_STR_AWS_DOMAIN}"
+ORB_VAL_ACCOUNT_URL="${!ORB_STR_ACCOUNT_ID}.dkr.ecr.${ORB_STR_REGION}.${ORB_STR_AWS_DOMAIN}"
 ORB_STR_PUBLIC_REGISTRY_ALIAS="$(circleci env subst "${ORB_STR_PUBLIC_REGISTRY_ALIAS}")"
 
-if [ -z "${!ORB_ENV_REGISTRY_ID}" ]; then
+if [ -z "${!ORB_STR_ACCOUNT_ID}" ]; then
   echo "The registry ID is not found. Please add the registry ID as an environment variable in CicleCI before continuing."
   exit 1
 fi

--- a/src/scripts/push_image.sh
+++ b/src/scripts/push_image.sh
@@ -2,10 +2,11 @@
 ORB_STR_REPO="$(circleci env subst "${ORB_STR_REPO}")"
 ORB_STR_TAG="$(circleci env subst "${ORB_STR_TAG}")"
 ORB_STR_REGION="$(circleci env subst "${ORB_STR_REGION}")"
-ORB_VAL_ACCOUNT_URL="${!ORB_STR_ACCOUNT_ID}.dkr.ecr.${ORB_STR_REGION}.${ORB_STR_AWS_DOMAIN}"
+ORB_STR_ACCOUNT_ID="$(circleci env subst "${ORB_STR_ACCOUNT_ID}")"
+ORB_VAL_ACCOUNT_URL="${ORB_STR_ACCOUNT_ID}.dkr.ecr.${ORB_STR_REGION}.${ORB_STR_AWS_DOMAIN}"
 ORB_STR_PUBLIC_REGISTRY_ALIAS="$(circleci env subst "${ORB_STR_PUBLIC_REGISTRY_ALIAS}")"
 
-if [ -z "${!ORB_STR_ACCOUNT_ID}" ]; then
+if [ -z "${ORB_STR_ACCOUNT_ID}" ]; then
   echo "The registry ID is not found. Please add the registry ID as an environment variable in CicleCI before continuing."
   exit 1
 fi


### PR DESCRIPTION
This `PR` renames the `registry_id` parameter to `account_id`, matching the `AWS` Documentation. 

It also changes the `type` of this parameter from `env_var_name` to `string` with the `default` value of `${AWS_ACCOUNT_ID}`