### PR TITLE
fix: skip_when_tags_exist inverted

### DIFF
--- a/src/scripts/tag_image.sh
+++ b/src/scripts/tag_image.sh
@@ -11,7 +11,7 @@ IFS="," read -ra ECR_TAGS <<<"${ORB_STR_TARGET_TAG}"
 
 for tag in "${ECR_TAGS[@]}"; do
     # if skip_when_tags_exist is true
-    if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "0" ]; then
+    if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "1" ]; then
         # tag image if tag does not exist
         if ! echo "${EXISTING_TAGS}" | grep "${tag}"; then
             aws ecr put-image --repository-name "${ORB_STR_REPO}" --image-tag "${tag}" --image-manifest "${MANIFEST}"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Command is doing the reverse of what is says in documentation.

### Description

When using `skip_when_tags_exist`, the behavior is inverted. When `true` it should check and skip. When `false`, it should just tag it.

The code currently on `master` does the exact opposite.