### PR TITLE
move to using docker buildx inspect with builder name to determine if builder exists

### DIFF
--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -69,7 +69,7 @@ if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "0" ] || [[ "${ORB_BOOL_SKIP_WHEN_TA
     context_args="--context builder"
   # the command ! docker buildx inspect --builder DLC_builder &> /dev/null will
   # attempt to inspect the builder named DLC_builder - this returns either true (inspect succeeds) or false (inspect fails)
-  # if docker buildx inspect --builder DLC_builder is not true, then perform a docker buildx create
+  # if docker buildx inspect --builder DLC_builder is not true then we perform a docker buildx create
   elif ! docker buildx inspect --builder DLC_builder &> /dev/null; then
     docker buildx create --name DLC_builder --use 
   fi 

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -67,8 +67,10 @@ if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "0" ] || [[ "${ORB_BOOL_SKIP_WHEN_TA
       docker --context builder buildx create --name DLC_builder --use
     fi
     context_args="--context builder"
-  # if no builder instance is currently used, create one
-  elif ! docker buildx inspect | grep -q "default * docker"; then 
+  # the command ! docker buildx inspect --builder DLC_builder &> /dev/null will
+  # attempt to inspect the builder named DLC_builder - this returns either true (inspect succeeds) or false (inspect fails)
+  # if docker buildx inspect --builder DLC_builder is not true, then perform a docker buildx create
+  elif ! docker buildx inspect --builder DLC_builder &> /dev/null; then
     docker buildx create --name DLC_builder --use 
   fi 
 


### PR DESCRIPTION
### Note

I don't know how effectively I'm able to test this PR (i.e. across builds with different Docker versions and across systems using CircleCI self-hosted runners and the CircleCI systems itself) - as of 2023-11-01 I've moved to draft status until either myself or someone else can test.

### Checklist

- [NA] All new jobs, commands, executors, parameters have descriptions
- [NA] Examples have been added for any significant new features
- [NA] README has been updated, if necessary

### Motivation, issues

This resolves the issue https://github.com/CircleCI-Public/aws-ecr-orb/issues/308

### Description

This change moves from utilizing a command `! docker buildx inspect | grep -q "default * docker"` which did not seem to locate an already existing `DLC_builder` to a single command that should run more reliably. A judgement call about "piping to grep" versus "a single command with an exit status".