### PR TITLE
fix: extra build arg expansion

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -312,7 +312,7 @@ workflows:
           profile_name: "OIDC-User"
           context: [CPE-OIDC]
           workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
+          repo: aws-ecr-orb-${CIRCLE_SHA1}-skip_when_tags_exist-<<matrix.executor>>
           tag: integration,myECRRepoTag
           dockerfile: sample/Dockerfile
           path: workspace
@@ -322,7 +322,7 @@ workflows:
             - run:
                 name: "Delete repository"
                 command: |
-                  aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
+                  aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
           matrix:
             parameters:
               executor: ["amd64", "arm64"]

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -107,72 +107,72 @@ workflows:
       - pre-integration-checkout-workspace-job:
           name: pre-integration
           filters: *filters
-      # - build-test-then-push-with-buildx:
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     attach_workspace: true
-      #     workspace_root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1}-build-test-then-push-with-buildx
-      #     create_repo: true
-      #     context: [CPE-OIDC]
-      #     tag: alpha
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     push_image: false
-      #     platform: linux/amd64
-      #     region: us-west-2
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-build-test-then-push-with-buildx --region us-west-2 --force
-      #     filters: *filters
-      #     requires: [pre-integration]
-      # - aws-ecr/build_and_push_image:
-      #     name: integration-test-multi-platform-without-push
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     attach_workspace: true
-      #     workspace_root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-multi-platform-without-push
-      #     create_repo: true
-      #     context: [CPE-OIDC]
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     executor: amd64
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-multi-platform-without-push --region us-west-2 --force
-      #     push_image: false
-      #     platform: linux/amd64,linux/arm64
-      #     filters: *filters
-      #     requires: [pre-integration]
-      # - aws-ecr/build_and_push_image:
-      #     name: integration-test-default-profile
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     attach_workspace: true
-      #     workspace_root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
-      #     create_repo: true
-      #     context: [CPE-OIDC]
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     extra_build_args: --compress
-      #     executor: amd64
-      #     lifecycle_policy_path: ./sample/lifecycle-policy.json
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1}-default-profile --force
-      #     platform: linux/amd64,linux/arm64
-      #     filters: *filters
-      #     requires: [pre-integration]
+      - build-test-then-push-with-buildx:
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          attach_workspace: true
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1}-build-test-then-push-with-buildx
+          create_repo: true
+          context: [CPE-OIDC]
+          tag: alpha
+          dockerfile: sample/Dockerfile
+          path: workspace
+          push_image: false
+          platform: linux/amd64
+          region: us-west-2
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-build-test-then-push-with-buildx --region us-west-2 --force
+          filters: *filters
+          requires: [pre-integration]
+      - aws-ecr/build_and_push_image:
+          name: integration-test-multi-platform-without-push
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          attach_workspace: true
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-multi-platform-without-push
+          create_repo: true
+          context: [CPE-OIDC]
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          executor: amd64
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-multi-platform-without-push --region us-west-2 --force
+          push_image: false
+          platform: linux/amd64,linux/arm64
+          filters: *filters
+          requires: [pre-integration]
+      - aws-ecr/build_and_push_image:
+          name: integration-test-default-profile
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          attach_workspace: true
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
+          create_repo: true
+          context: [CPE-OIDC]
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra_build_args: --compress
+          executor: amd64
+          lifecycle_policy_path: ./sample/lifecycle-policy.json
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1}-default-profile --force
+          platform: linux/amd64,linux/arm64
+          filters: *filters
+          requires: [pre-integration]
       - aws-ecr/build_and_push_image:
           name: integration-test-cache-to-flag
           auth:
@@ -189,162 +189,162 @@ workflows:
           executor: amd64
           filters: *filters
           requires: [pre-integration]
-      # - aws-ecr/build_and_push_image:
-      #     name: integration-test-pubic-registry
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #           profile_name: "OIDC-User"
-      #     attach_workspace: true
-      #     workspace_root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public_registry
-      #     create_repo: true
-      #     region: "us-west-2"
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: Dockerfile
-      #     path: ./sample
-      #     extra_build_args: --compress
-      #     executor: arm64
-      #     public_registry: true
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1}-public_registry --force --profile OIDC-User
-      #     platform: linux/arm64,linux/amd64
-      #     filters: *filters
-      #     requires: [pre-integration]
-      # - aws-ecr/build_and_push_image:
-      #     pre-steps:
-      #       - run:
-      #           name: "Export NPM_TOKEN"
-      #           command: echo 'export NPM_TOKEN="00000000-0000-0000-0000-000000000000"' >> "$BASH_ENV"
-      #     name: integration-test-named-profile
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #           profile_name: "OIDC-User"
-      #     attach_workspace: true
-      #     region: "us-west-2"
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     workspace_root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-      #     create_repo: true
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     extra_build_args: >-
-      #       --build-arg NPM_TOKEN=${NPM_TOKEN}
-      #       --build-arg=${CIRCLE_SHA1:0:7}
-      #     set_repo_policy: true
-      #     repo_policy_path: ./sample/repo-policy.json
-      #     executor: amd64
-      #     filters: *filters
-      #     requires: [pre-integration]
-      # - tag-ecr-image:
-      #     name: integration-test-tag-existing-image
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #           profile_name: "OIDC-User"
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-      #     region: "us-west-2"
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     source_tag: integration
-      #     target_tag: latest
-      #     requires:
-      #       - integration-test-named-profile
-      # - tag-ecr-image:
-      #     name: integration-test-tag-image-with-existing-tag
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #           profile_name: "OIDC-User"
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-      #     region: "us-west-2"
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     source_tag: integration
-      #     target_tag: alpha,latest
-      #     skip_when_tags_exist: true
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-named-profile --force --profile OIDC-User
-      #     filters: *filters
-      #     requires:
-      #       - integration-test-tag-existing-image
-      # - aws-ecr/build_and_push_image:
-      #     name: integration-test-skip_when_tags_exist-populate-image-<<matrix.executor>>
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #           profile_name: "OIDC-User"
-      #     attach_workspace: true
-      #     region: "us-west-2"
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     workspace_root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
-      #     create_repo: true
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: Dockerfile
-      #     path: ./sample
-      #     platform: linux/amd64,linux/arm64
-      #     extra_build_args: --compress
-      #     skip_when_tags_exist: true
-      #     matrix:
-      #       parameters:
-      #         executor: ["arm64", "amd64"]
-      #     filters: *filters
-      #     requires: [pre-integration]
-      # - aws-ecr/build_and_push_image:
-      #     name: integration-test-skip_when_tags_exist-<<matrix.executor>>
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #           profile_name: "OIDC-User"
-      #     attach_workspace: true
-      #     region: "us-west-2"
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     workspace_root: workspace
-      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
-      #     tag: integration,myECRRepoTag
-      #     dockerfile: sample/Dockerfile
-      #     path: workspace
-      #     extra_build_args: --compress
-      #     skip_when_tags_exist: true
-      #     post-steps:
-      #       - run:
-      #           name: "Delete repository"
-      #           command: |
-      #             aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
-      #     matrix:
-      #       parameters:
-      #         executor: ["amd64", "arm64"]
-      #     filters: *filters
-      #     requires:
-      #       - integration-test-skip_when_tags_exist-populate-image-amd64
-      #       - integration-test-skip_when_tags_exist-populate-image-arm64
-      # - orb-tools/lint:
-      #     filters: *filters
-      # - orb-tools/pack:
-      #     filters: *filters
-      # - orb-tools/review:
-      #     filters: *release-filters
-      # - orb-tools/publish:
-      #     orb_name: circleci/aws-ecr
-      #     vcs_type: << pipeline.project.type >>
-      #     pub_type: production
-      #     enable_pr_comment: true
-      #     requires: [ orb-tools/lint, orb-tools/review, orb-tools/pack, integration-test-default-profile, integration-test-pubic-registry, integration-test-skip_when_tags_exist-amd64, integration-test-skip_when_tags_exist-arm64, integration-test-named-profile, integration-test-tag-existing-image, integration-test-tag-image-with-existing-tag ]
-      #     github_token: GHI_TOKEN
-      #     context: orb-publisher
-      #     filters: *release-filters
+      - aws-ecr/build_and_push_image:
+          name: integration-test-pubic-registry
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "OIDC-User"
+          attach_workspace: true
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public_registry
+          create_repo: true
+          region: "us-west-2"
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          tag: integration,myECRRepoTag
+          dockerfile: Dockerfile
+          path: ./sample
+          extra_build_args: --compress
+          executor: arm64
+          public_registry: true
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1}-public_registry --force --profile OIDC-User
+          platform: linux/arm64,linux/amd64
+          filters: *filters
+          requires: [pre-integration]
+      - aws-ecr/build_and_push_image:
+          pre-steps:
+            - run:
+                name: "Export NPM_TOKEN"
+                command: echo 'export NPM_TOKEN="00000000-0000-0000-0000-000000000000"' >> "$BASH_ENV"
+          name: integration-test-named-profile
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "OIDC-User"
+          attach_workspace: true
+          region: "us-west-2"
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+          create_repo: true
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra_build_args: >-
+            --build-arg NPM_TOKEN=${NPM_TOKEN}
+            --build-arg=${CIRCLE_SHA1:0:7}
+          set_repo_policy: true
+          repo_policy_path: ./sample/repo-policy.json
+          executor: amd64
+          filters: *filters
+          requires: [pre-integration]
+      - tag-ecr-image:
+          name: integration-test-tag-existing-image
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "OIDC-User"
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+          region: "us-west-2"
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          source_tag: integration
+          target_tag: latest
+          requires:
+            - integration-test-named-profile
+      - tag-ecr-image:
+          name: integration-test-tag-image-with-existing-tag
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "OIDC-User"
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+          region: "us-west-2"
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          source_tag: integration
+          target_tag: alpha,latest
+          skip_when_tags_exist: true
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-named-profile --force --profile OIDC-User
+          filters: *filters
+          requires:
+            - integration-test-tag-existing-image
+      - aws-ecr/build_and_push_image:
+          name: integration-test-skip_when_tags_exist-populate-image-<<matrix.executor>>
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "OIDC-User"
+          attach_workspace: true
+          region: "us-west-2"
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
+          create_repo: true
+          tag: integration,myECRRepoTag
+          dockerfile: Dockerfile
+          path: ./sample
+          platform: linux/amd64,linux/arm64
+          extra_build_args: --compress
+          skip_when_tags_exist: true
+          matrix:
+            parameters:
+              executor: ["arm64", "amd64"]
+          filters: *filters
+          requires: [pre-integration]
+      - aws-ecr/build_and_push_image:
+          name: integration-test-skip_when_tags_exist-<<matrix.executor>>
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "OIDC-User"
+          attach_workspace: true
+          region: "us-west-2"
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          workspace_root: workspace
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
+          tag: integration,myECRRepoTag
+          dockerfile: sample/Dockerfile
+          path: workspace
+          extra_build_args: --compress
+          skip_when_tags_exist: true
+          post-steps:
+            - run:
+                name: "Delete repository"
+                command: |
+                  aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
+          matrix:
+            parameters:
+              executor: ["amd64", "arm64"]
+          filters: *filters
+          requires:
+            - integration-test-skip_when_tags_exist-populate-image-amd64
+            - integration-test-skip_when_tags_exist-populate-image-arm64
+      - orb-tools/lint:
+          filters: *filters
+      - orb-tools/pack:
+          filters: *filters
+      - orb-tools/review:
+          filters: *release-filters
+      - orb-tools/publish:
+          orb_name: circleci/aws-ecr
+          vcs_type: << pipeline.project.type >>
+          pub_type: production
+          enable_pr_comment: true
+          requires: [ orb-tools/lint, orb-tools/review, orb-tools/pack, integration-test-default-profile, integration-test-pubic-registry, integration-test-skip_when_tags_exist-amd64, integration-test-skip_when_tags_exist-arm64, integration-test-named-profile, integration-test-tag-existing-image, integration-test-tag-image-with-existing-tag ]
+          github_token: GHI_TOKEN
+          context: orb-publisher
+          filters: *release-filters
 executors:
   amd64:
     machine:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -107,72 +107,72 @@ workflows:
       - pre-integration-checkout-workspace-job:
           name: pre-integration
           filters: *filters
-      - build-test-then-push-with-buildx:
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          attach_workspace: true
-          workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1}-build-test-then-push-with-buildx
-          create_repo: true
-          context: [CPE-OIDC]
-          tag: alpha
-          dockerfile: sample/Dockerfile
-          path: workspace
-          push_image: false
-          platform: linux/amd64
-          region: us-west-2
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-build-test-then-push-with-buildx --region us-west-2 --force
-          filters: *filters
-          requires: [pre-integration]
-      - aws-ecr/build_and_push_image:
-          name: integration-test-multi-platform-without-push
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          attach_workspace: true
-          workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-multi-platform-without-push
-          create_repo: true
-          context: [CPE-OIDC]
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          executor: amd64
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-multi-platform-without-push --region us-west-2 --force
-          push_image: false
-          platform: linux/amd64,linux/arm64
-          filters: *filters
-          requires: [pre-integration]
-      - aws-ecr/build_and_push_image:
-          name: integration-test-default-profile
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          attach_workspace: true
-          workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
-          create_repo: true
-          context: [CPE-OIDC]
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra_build_args: --compress
-          executor: amd64
-          lifecycle_policy_path: ./sample/lifecycle-policy.json
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1}-default-profile --force
-          platform: linux/amd64,linux/arm64
-          filters: *filters
-          requires: [pre-integration]
+      # - build-test-then-push-with-buildx:
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     attach_workspace: true
+      #     workspace_root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1}-build-test-then-push-with-buildx
+      #     create_repo: true
+      #     context: [CPE-OIDC]
+      #     tag: alpha
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     push_image: false
+      #     platform: linux/amd64
+      #     region: us-west-2
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-build-test-then-push-with-buildx --region us-west-2 --force
+      #     filters: *filters
+      #     requires: [pre-integration]
+      # - aws-ecr/build_and_push_image:
+      #     name: integration-test-multi-platform-without-push
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     attach_workspace: true
+      #     workspace_root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-multi-platform-without-push
+      #     create_repo: true
+      #     context: [CPE-OIDC]
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     executor: amd64
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-multi-platform-without-push --region us-west-2 --force
+      #     push_image: false
+      #     platform: linux/amd64,linux/arm64
+      #     filters: *filters
+      #     requires: [pre-integration]
+      # - aws-ecr/build_and_push_image:
+      #     name: integration-test-default-profile
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     attach_workspace: true
+      #     workspace_root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
+      #     create_repo: true
+      #     context: [CPE-OIDC]
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra_build_args: --compress
+      #     executor: amd64
+      #     lifecycle_policy_path: ./sample/lifecycle-policy.json
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1}-default-profile --force
+      #     platform: linux/amd64,linux/arm64
+      #     filters: *filters
+      #     requires: [pre-integration]
       - aws-ecr/build_and_push_image:
           name: integration-test-cache-to-flag
           auth:
@@ -184,167 +184,167 @@ workflows:
           context: [CPE-OIDC]
           dockerfile: sample/Dockerfile
           path: workspace
-          extra_build_args: --cache-to type=local,dest=/tmp
+          extra_build_args: --cache-to type=local,dest=/tmp --compress
           push_image: false
           executor: amd64
           filters: *filters
           requires: [pre-integration]
-      - aws-ecr/build_and_push_image:
-          name: integration-test-pubic-registry
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
-          attach_workspace: true
-          workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public_registry
-          create_repo: true
-          region: "us-west-2"
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          tag: integration,myECRRepoTag
-          dockerfile: Dockerfile
-          path: ./sample
-          extra_build_args: --compress
-          executor: arm64
-          public_registry: true
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1}-public_registry --force --profile OIDC-User
-          platform: linux/arm64,linux/amd64
-          filters: *filters
-          requires: [pre-integration]
-      - aws-ecr/build_and_push_image:
-          pre-steps:
-            - run:
-                name: "Export NPM_TOKEN"
-                command: echo 'export NPM_TOKEN="00000000-0000-0000-0000-000000000000"' >> "$BASH_ENV"
-          name: integration-test-named-profile
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
-          attach_workspace: true
-          region: "us-west-2"
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-          create_repo: true
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra_build_args: >-
-            --build-arg NPM_TOKEN=${NPM_TOKEN}
-            --build-arg=${CIRCLE_SHA1:0:7}
-          set_repo_policy: true
-          repo_policy_path: ./sample/repo-policy.json
-          executor: amd64
-          filters: *filters
-          requires: [pre-integration]
-      - tag-ecr-image:
-          name: integration-test-tag-existing-image
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-          region: "us-west-2"
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          source_tag: integration
-          target_tag: latest
-          requires:
-            - integration-test-named-profile
-      - tag-ecr-image:
-          name: integration-test-tag-image-with-existing-tag
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
-          region: "us-west-2"
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          source_tag: integration
-          target_tag: alpha,latest
-          skip_when_tags_exist: true
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-named-profile --force --profile OIDC-User
-          filters: *filters
-          requires:
-            - integration-test-tag-existing-image
-      - aws-ecr/build_and_push_image:
-          name: integration-test-skip_when_tags_exist-populate-image-<<matrix.executor>>
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
-          attach_workspace: true
-          region: "us-west-2"
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
-          create_repo: true
-          tag: integration,myECRRepoTag
-          dockerfile: Dockerfile
-          path: ./sample
-          platform: linux/amd64,linux/arm64
-          extra_build_args: --compress
-          skip_when_tags_exist: true
-          matrix:
-            parameters:
-              executor: ["arm64", "amd64"]
-          filters: *filters
-          requires: [pre-integration]
-      - aws-ecr/build_and_push_image:
-          name: integration-test-skip_when_tags_exist-<<matrix.executor>>
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
-          attach_workspace: true
-          region: "us-west-2"
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
-          tag: integration,myECRRepoTag
-          dockerfile: sample/Dockerfile
-          path: workspace
-          extra_build_args: --compress
-          skip_when_tags_exist: true
-          post-steps:
-            - run:
-                name: "Delete repository"
-                command: |
-                  aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
-          matrix:
-            parameters:
-              executor: ["amd64", "arm64"]
-          filters: *filters
-          requires:
-            - integration-test-skip_when_tags_exist-populate-image-amd64
-            - integration-test-skip_when_tags_exist-populate-image-arm64
-      - orb-tools/lint:
-          filters: *filters
-      - orb-tools/pack:
-          filters: *filters
-      - orb-tools/review:
-          filters: *release-filters
-      - orb-tools/publish:
-          orb_name: circleci/aws-ecr
-          vcs_type: << pipeline.project.type >>
-          pub_type: production
-          enable_pr_comment: true
-          requires: [ orb-tools/lint, orb-tools/review, orb-tools/pack, integration-test-default-profile, integration-test-pubic-registry, integration-test-skip_when_tags_exist-amd64, integration-test-skip_when_tags_exist-arm64, integration-test-named-profile, integration-test-tag-existing-image, integration-test-tag-image-with-existing-tag ]
-          github_token: GHI_TOKEN
-          context: orb-publisher
-          filters: *release-filters
+      # - aws-ecr/build_and_push_image:
+      #     name: integration-test-pubic-registry
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #           profile_name: "OIDC-User"
+      #     attach_workspace: true
+      #     workspace_root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public_registry
+      #     create_repo: true
+      #     region: "us-west-2"
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: Dockerfile
+      #     path: ./sample
+      #     extra_build_args: --compress
+      #     executor: arm64
+      #     public_registry: true
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1}-public_registry --force --profile OIDC-User
+      #     platform: linux/arm64,linux/amd64
+      #     filters: *filters
+      #     requires: [pre-integration]
+      # - aws-ecr/build_and_push_image:
+      #     pre-steps:
+      #       - run:
+      #           name: "Export NPM_TOKEN"
+      #           command: echo 'export NPM_TOKEN="00000000-0000-0000-0000-000000000000"' >> "$BASH_ENV"
+      #     name: integration-test-named-profile
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #           profile_name: "OIDC-User"
+      #     attach_workspace: true
+      #     region: "us-west-2"
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     workspace_root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+      #     create_repo: true
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra_build_args: >-
+      #       --build-arg NPM_TOKEN=${NPM_TOKEN}
+      #       --build-arg=${CIRCLE_SHA1:0:7}
+      #     set_repo_policy: true
+      #     repo_policy_path: ./sample/repo-policy.json
+      #     executor: amd64
+      #     filters: *filters
+      #     requires: [pre-integration]
+      # - tag-ecr-image:
+      #     name: integration-test-tag-existing-image
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #           profile_name: "OIDC-User"
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+      #     region: "us-west-2"
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     source_tag: integration
+      #     target_tag: latest
+      #     requires:
+      #       - integration-test-named-profile
+      # - tag-ecr-image:
+      #     name: integration-test-tag-image-with-existing-tag
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #           profile_name: "OIDC-User"
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile
+      #     region: "us-west-2"
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     source_tag: integration
+      #     target_tag: alpha,latest
+      #     skip_when_tags_exist: true
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-named-profile --force --profile OIDC-User
+      #     filters: *filters
+      #     requires:
+      #       - integration-test-tag-existing-image
+      # - aws-ecr/build_and_push_image:
+      #     name: integration-test-skip_when_tags_exist-populate-image-<<matrix.executor>>
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #           profile_name: "OIDC-User"
+      #     attach_workspace: true
+      #     region: "us-west-2"
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     workspace_root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
+      #     create_repo: true
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: Dockerfile
+      #     path: ./sample
+      #     platform: linux/amd64,linux/arm64
+      #     extra_build_args: --compress
+      #     skip_when_tags_exist: true
+      #     matrix:
+      #       parameters:
+      #         executor: ["arm64", "amd64"]
+      #     filters: *filters
+      #     requires: [pre-integration]
+      # - aws-ecr/build_and_push_image:
+      #     name: integration-test-skip_when_tags_exist-<<matrix.executor>>
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #           profile_name: "OIDC-User"
+      #     attach_workspace: true
+      #     region: "us-west-2"
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     workspace_root: workspace
+      #     repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
+      #     tag: integration,myECRRepoTag
+      #     dockerfile: sample/Dockerfile
+      #     path: workspace
+      #     extra_build_args: --compress
+      #     skip_when_tags_exist: true
+      #     post-steps:
+      #       - run:
+      #           name: "Delete repository"
+      #           command: |
+      #             aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
+      #     matrix:
+      #       parameters:
+      #         executor: ["amd64", "arm64"]
+      #     filters: *filters
+      #     requires:
+      #       - integration-test-skip_when_tags_exist-populate-image-amd64
+      #       - integration-test-skip_when_tags_exist-populate-image-arm64
+      # - orb-tools/lint:
+      #     filters: *filters
+      # - orb-tools/pack:
+      #     filters: *filters
+      # - orb-tools/review:
+      #     filters: *release-filters
+      # - orb-tools/publish:
+      #     orb_name: circleci/aws-ecr
+      #     vcs_type: << pipeline.project.type >>
+      #     pub_type: production
+      #     enable_pr_comment: true
+      #     requires: [ orb-tools/lint, orb-tools/review, orb-tools/pack, integration-test-default-profile, integration-test-pubic-registry, integration-test-skip_when_tags_exist-amd64, integration-test-skip_when_tags_exist-arm64, integration-test-named-profile, integration-test-tag-existing-image, integration-test-tag-image-with-existing-tag ]
+      #     github_token: GHI_TOKEN
+      #     context: orb-publisher
+      #     filters: *release-filters
 executors:
   amd64:
     machine:

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -14,6 +14,13 @@ ORB_STR_PROFILE_NAME="$(circleci env subst "${ORB_STR_PROFILE_NAME}")"
 ORB_STR_PLATFORM="$(circleci env subst "${ORB_STR_PLATFORM}")"
 ORB_STR_LIFECYCLE_POLICY_PATH="$(circleci env subst "${ORB_STR_LIFECYCLE_POLICY_PATH}")"
 
+
+if [ -n "${ORB_STR_EXTRA_BUILD_ARGS}" ]; then
+  IFS=" " read -a args -r <<< "${ORB_STR_EXTRA_BUILD_ARGS[@]}"
+  for arg in "${args[@]}"; do
+    set -- "$@" "$arg"
+  done
+fi
 ECR_COMMAND="ecr"
 number_of_tags_in_ecr=0
 
@@ -80,7 +87,6 @@ set -x
     ${docker_tag_args:+$docker_tag_args} \
     --platform "${ORB_STR_PLATFORM}" \
     --progress plain \
-    ${ORB_STR_EXTRA_BUILD_ARGS:+$ORB_STR_EXTRA_BUILD_ARGS} \
     "$@" \
     "${ORB_EVAL_BUILD_PATH}"
 set +x


### PR DESCRIPTION
This pull request fixes the expansion of the `extra_build_args` parameter. Users have reported that  having multiple flags causes the entire string to be wrapped in single quotes, making jobs fail.