### PR TITLE
fix: set profile when calling aws ecr put-lifecycle-policy (#311)

### DIFF
--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -55,6 +55,7 @@ if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "0" ] || [[ "${ORB_BOOL_SKIP_WHEN_TA
 
     if [ -n "${ORB_STR_LIFECYCLE_POLICY_PATH}" ]; then
       aws ecr put-lifecycle-policy \
+        --profile "${ORB_STR_PROFILE_NAME}" \
         --repository-name "${ORB_STR_REPO}" \
         --lifecycle-policy-text "file://${ORB_STR_LIFECYCLE_POLICY_PATH}"
     fi


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Fix for https://github.com/CircleCI-Public/aws-ecr-orb/issues/311

### Description

Specify profile name when calling aws ecr put-lifecycle-policy.