### PR TITLE
docs: rm description re: AWS CLI installations

### DIFF
--- a/src/commands/build_and_push_image.yml
+++ b/src/commands/build_and_push_image.yml
@@ -1,5 +1,4 @@
 description: >
-  Install AWS CLI Version 2 and configure credentials if needed.
   Log into Amazon ECR, build and push a Docker image to the specified repository.
   NOTE: Some commands may not work with AWS CLI Version 1.
 parameters:

--- a/src/commands/build_image.yml
+++ b/src/commands/build_image.yml
@@ -1,5 +1,5 @@
 description: >
-  Install AWS CLI Version 2 and configure credentials if needed to Build a Docker image with docker buildx.
+  Build a Docker image with docker buildx.
   NOTE: Some commands may not work with AWS CLI Version 1.
 
 parameters:

--- a/src/commands/create_repo.yml
+++ b/src/commands/create_repo.yml
@@ -1,5 +1,5 @@
 description: >
-  Install AWS CLI Version 2 and configure credentials if needed to create a new AWS ECR repository.
+  Create a new AWS ECR repository.
   NOTE: Some commands may not work with AWS CLI Version 1.
 
 parameters:

--- a/src/commands/ecr_login.yml
+++ b/src/commands/ecr_login.yml
@@ -1,5 +1,5 @@
 description: >
-  Install AWS CLI Version 2 and configure credentials if needed to authenticate into the Amazon ECR service.
+  Authenticate into the Amazon ECR service.
   NOTE: Some commands may not work with AWS CLI Version 1.
 
 parameters:

--- a/src/commands/push_image.yml
+++ b/src/commands/push_image.yml
@@ -1,5 +1,5 @@
 description: >
-  Install AWS CLI Version 2 and configure credentials if needed to push a container image to the Amazon ECR registry
+  Push a container image to the Amazon ECR registry
   NOTE: Some commands may not work with AWS CLI Version 1.
 parameters:
   account_id:

--- a/src/commands/set_repo_policy.yml
+++ b/src/commands/set_repo_policy.yml
@@ -1,5 +1,5 @@
 description: >
-  Install AWS CLI Version 2 and configure credentials if needed to set a repository policy on an AWS ECR repository
+  Set a repository policy on an AWS ECR repository
   NOTE: Some commands may not work with AWS CLI Version 1.
 
 parameters:

--- a/src/commands/tag_image.yml
+++ b/src/commands/tag_image.yml
@@ -1,5 +1,5 @@
 description: >
-  Install AWS CLI Version 2 and configure credentials if needed to add a tag to an existing published image
+  Add a tag to an existing published image
   NOTE: Some commands may not work with AWS CLI Version 1.
 
 parameters:

--- a/src/jobs/build_and_push_image.yml
+++ b/src/jobs/build_and_push_image.yml
@@ -1,6 +1,6 @@
 description: >
-  Install AWS CLI Version 2, if needed, and configure credentials to log into Amazon ECR
-  and push image to repository. Authenticate with OIDC or static AWS keys using the aws-cli/setup command is required.
+  Log into Amazon ECR and push image to repository.
+  Authentication with OIDC or static AWS keys using the aws-cli/setup command is required.
   NOTE: Some commands may not work with AWS CLI Version 1.
 
 executor: << parameters.executor >>


### PR DESCRIPTION
Fixes the commands & jobs' descriptions re: AWS CLI installations.

As of v9.x, the commands & jobs do not explicitly install AWS CLI by default.
Rather, it is assumed that the executor chosen would have the AWS CLI already installed. 
For instance, the `aws-ecr/default` executor is the `ubuntu-2004:2022.04.2` Machine executor, which comes pre-installed with AWS CLI.

I understand that alternatively, users can ensure the AWS CLI is installed via:

1)  as part of the `auth` parameter's steps when using the build_and_push_image job, or
2) adding AWS installation steps as [`pre-steps` if needed](https://circleci.com/docs/reusing-config/#using-pre-and-post-steps)

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
