### PR TITLE
refactor: revert to eval

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -113,7 +113,7 @@ workflows:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           attach_workspace: true
           workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1}-build-test-then-push-with-buildx
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-build-test-then-push-with-buildx
           create_repo: true
           context: [CPE-OIDC]
           tag: alpha
@@ -125,7 +125,7 @@ workflows:
           post-steps:
             - run:
                 name: "Delete repository"
-                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-build-test-then-push-with-buildx --region us-west-2 --force
+                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-build-test-then-push-with-buildx --region us-west-2 --force
           filters: *filters
           requires: [pre-integration]
       - aws-ecr/build_and_push_image:
@@ -145,7 +145,7 @@ workflows:
           post-steps:
             - run:
                 name: "Delete repository"
-                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-multi-platform-without-push --region us-west-2 --force
+                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-multi-platform-without-push --region us-west-2 --force
           push_image: false
           platform: linux/amd64,linux/arm64
           filters: *filters
@@ -169,7 +169,7 @@ workflows:
           post-steps:
             - run:
                 name: "Delete repository"
-                command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1}-default-profile --force
+                command: aws ecr delete-repository --repository-name --region us-west-2 aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile --force
           platform: linux/amd64,linux/arm64
           filters: *filters
           requires: [pre-integration]
@@ -211,7 +211,7 @@ workflows:
           post-steps:
             - run:
                 name: "Delete repository"
-                command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1}-public_registry --force --profile OIDC-User
+                command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public_registry --force --profile OIDC-User
           platform: linux/arm64,linux/amd64
           filters: *filters
           requires: [pre-integration]
@@ -273,7 +273,7 @@ workflows:
           post-steps:
             - run:
                 name: "Delete repository"
-                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-named-profile --force --profile OIDC-User
+                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile --force --profile OIDC-User
           filters: *filters
           requires:
             - integration-test-tag-existing-image
@@ -312,7 +312,7 @@ workflows:
           profile_name: "OIDC-User"
           context: [CPE-OIDC]
           workspace_root: workspace
-          repo: aws-ecr-orb-${CIRCLE_SHA1}-skip_when_tags_exist-<<matrix.executor>>
+          repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
           tag: integration,myECRRepoTag
           dockerfile: sample/Dockerfile
           path: workspace
@@ -322,7 +322,7 @@ workflows:
             - run:
                 name: "Delete repository"
                 command: |
-                  aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
+                  aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
           matrix:
             parameters:
               executor: ["amd64", "arm64"]

--- a/src/commands/build_image.yml
+++ b/src/commands/build_image.yml
@@ -109,21 +109,21 @@ steps:
   - run:
       name: Build Docker Image with buildx
       environment:
-        ORB_STR_TAG: << parameters.tag >>
-        ORB_BOOL_SKIP_WHEN_TAGS_EXIST: <<parameters.skip_when_tags_exist>>
-        ORB_STR_REPO: << parameters.repo >>
-        ORB_STR_EXTRA_BUILD_ARGS: <<parameters.extra_build_args>>
-        ORB_EVAL_PATH: <<parameters.path>>
-        ORB_STR_DOCKERFILE: <<parameters.dockerfile>>
-        ORB_STR_PROFILE_NAME: <<parameters.profile_name>>
-        ORB_STR_ACCOUNT_ID: <<parameters.account_id>>
-        ORB_STR_REGION: <<parameters.region>>
-        ORB_STR_PLATFORM: <<parameters.platform>>
-        ORB_BOOL_PUBLIC_REGISTRY: <<parameters.public_registry>>
-        ORB_BOOL_PUSH_IMAGE: <<parameters.push_image>>
-        ORB_STR_LIFECYCLE_POLICY_PATH: <<parameters.lifecycle_policy_path>>
-        ORB_STR_PUBLIC_REGISTRY_ALIAS: <<parameters.public_registry_alias>>
-        ORB_EVAL_BUILD_PATH: <<parameters.build_path>>
-        ORB_STR_AWS_DOMAIN: <<parameters.aws_domain>>
+        AWS_ECR_STR_TAG: << parameters.tag >>
+        AWS_ECR_BOOL_SKIP_WHEN_TAGS_EXIST: <<parameters.skip_when_tags_exist>>
+        AWS_ECR_STR_REPO: << parameters.repo >>
+        AWS_ECR_STR_EXTRA_BUILD_ARGS: <<parameters.extra_build_args>>
+        AWS_ECR_EVAL_PATH: <<parameters.path>>
+        AWS_ECR_STR_DOCKERFILE: <<parameters.dockerfile>>
+        AWS_ECR_STR_PROFILE_NAME: <<parameters.profile_name>>
+        AWS_ECR_STR_ACCOUNT_ID: <<parameters.account_id>>
+        AWS_ECR_STR_REGION: <<parameters.region>>
+        AWS_ECR_STR_PLATFORM: <<parameters.platform>>
+        AWS_ECR_BOOL_PUBLIC_REGISTRY: <<parameters.public_registry>>
+        AWS_ECR_BOOL_PUSH_IMAGE: <<parameters.push_image>>
+        AWS_ECR_STR_LIFECYCLE_POLICY_PATH: <<parameters.lifecycle_policy_path>>
+        AWS_ECR_STR_PUBLIC_REGISTRY_ALIAS: <<parameters.public_registry_alias>>
+        AWS_ECR_EVAL_BUILD_PATH: <<parameters.build_path>>
+        AWS_ECR_STR_AWS_DOMAIN: <<parameters.aws_domain>>
       command: <<include(scripts/docker_buildx.sh)>>
       no_output_timeout: <<parameters.no_output_timeout>>

--- a/src/commands/create_repo.yml
+++ b/src/commands/create_repo.yml
@@ -45,11 +45,11 @@ steps:
   - run:
       name: Create Repository
       environment:
-        ORB_STR_PROFILE_NAME: <<parameters.profile_name>>
-        ORB_STR_REGION: <<parameters.region>>
-        ORB_STR_REPO: <<parameters.repo>>
-        ORB_BOOL_REPO_SCAN_ON_PUSH: <<parameters.repo_scan_on_push>>
-        ORB_BOOL_PUBLIC_REGISTRY: <<parameters.public_registry>>
-        ORB_ENUM_ENCRYPTION_TYPE: <<parameters.repo_encryption_type>>
-        ORB_STR_ENCRYPTION_KMS_KEY: <<parameters.encryption_kms_key>>
+        AWS_ECR_STR_PROFILE_NAME: <<parameters.profile_name>>
+        AWS_ECR_STR_REGION: <<parameters.region>>
+        AWS_ECR_STR_REPO: <<parameters.repo>>
+        AWS_ECR_BOOL_REPO_SCAN_ON_PUSH: <<parameters.repo_scan_on_push>>
+        AWS_ECR_BOOL_PUBLIC_REGISTRY: <<parameters.public_registry>>
+        AWS_ECR_ENUM_ENCRYPTION_TYPE: <<parameters.repo_encryption_type>>
+        AWS_ECR_STR_ENCRYPTION_KMS_KEY: <<parameters.encryption_kms_key>>
       command: <<include(scripts/create_repo.sh)>>

--- a/src/commands/ecr_login.yml
+++ b/src/commands/ecr_login.yml
@@ -37,9 +37,9 @@ steps:
   - run:
       name: Log into Amazon ECR with profile <<parameters.profile_name>>
       environment:
-        ORB_STR_PROFILE_NAME: <<parameters.profile_name>>
-        ORB_STR_ACCOUNT_ID: <<parameters.account_id>>
-        ORB_STR_REGION: <<parameters.region>>
-        ORB_BOOL_PUBLIC_REGISTRY: <<parameters.public_registry>>
-        ORB_STR_AWS_DOMAIN: <<parameters.aws_domain>>
+        AWS_ECR_STR_PROFILE_NAME: <<parameters.profile_name>>
+        AWS_ECR_STR_ACCOUNT_ID: <<parameters.account_id>>
+        AWS_ECR_STR_REGION: <<parameters.region>>
+        AWS_ECR_BOOL_PUBLIC_REGISTRY: <<parameters.public_registry>>
+        AWS_ECR_STR_AWS_DOMAIN: <<parameters.aws_domain>>
       command: <<include(scripts/ecr_login.sh)>>

--- a/src/commands/push_image.yml
+++ b/src/commands/push_image.yml
@@ -39,11 +39,11 @@ steps:
   - run:
       name: Push image to AWS ECR
       environment:
-        ORB_STR_REPO: << parameters.repo >>
-        ORB_STR_REGION: << parameters.region >>
-        ORB_STR_TAG: << parameters.tag >>
-        ORB_BOOL_PUBLIC_REGISTRY: <<parameters.public_registry>>
-        ORB_STR_PUBLIC_REGISTRY_ALIAS: <<parameters.public_registry_alias>>
-        ORB_STR_ACCOUNT_ID: << parameters.account_id >>
-        ORB_STR_AWS_DOMAIN: <<parameters.aws_domain>>
+        AWS_ECR_STR_REPO: << parameters.repo >>
+        AWS_ECR_STR_REGION: << parameters.region >>
+        AWS_ECR_STR_TAG: << parameters.tag >>
+        AWS_ECR_BOOL_PUBLIC_REGISTRY: <<parameters.public_registry>>
+        AWS_ECR_STR_PUBLIC_REGISTRY_ALIAS: <<parameters.public_registry_alias>>
+        AWS_ECR_STR_ACCOUNT_ID: << parameters.account_id >>
+        AWS_ECR_STR_AWS_DOMAIN: <<parameters.aws_domain>>
       command: << include(scripts/push_image.sh) >>

--- a/src/commands/set_repo_policy.yml
+++ b/src/commands/set_repo_policy.yml
@@ -33,9 +33,9 @@ steps:
   - run:
       name: Set Repository Policy
       environment:
-        ORB_STR_PROFILE_NAME: <<parameters.profile_name>>
-        ORB_STR_REGION: <<parameters.region>>
-        ORB_STR_REPO: <<parameters.repo>>
-        ORB_BOOL_PUBLIC_REGISTRY: <<parameters.public_registry>>
-        ORB_STR_REPO_POLICY_PATH: <<parameters.repo_policy_path>>
+        AWS_ECR_STR_PROFILE_NAME: <<parameters.profile_name>>
+        AWS_ECR_STR_REGION: <<parameters.region>>
+        AWS_ECR_STR_REPO: <<parameters.repo>>
+        AWS_ECR_BOOL_PUBLIC_REGISTRY: <<parameters.public_registry>>
+        AWS_ECR_STR_REPO_POLICY_PATH: <<parameters.repo_policy_path>>
       command: <<include(scripts/set_repo_policy.sh)>>

--- a/src/commands/tag_image.yml
+++ b/src/commands/tag_image.yml
@@ -25,8 +25,8 @@ steps:
   - run:
       name: <<parameters.target_tag>> tag to <<parameters.repo>>:<<parameters.source_tag>>
       environment:
-        ORB_STR_REPO: <<parameters.repo>>
-        ORB_STR_SOURCE_TAG: <<parameters.source_tag>>
-        ORB_STR_TARGET_TAG: <<parameters.target_tag>>
-        ORB_BOOL_SKIP_WHEN_TAGS_EXIST: <<parameters.skip_when_tags_exist>>
+        AWS_ECR_STR_REPO: <<parameters.repo>>
+        AWS_ECR_STR_SOURCE_TAG: <<parameters.source_tag>>
+        AWS_ECR_STR_TARGET_TAG: <<parameters.target_tag>>
+        AWS_ECR_BOOL_SKIP_WHEN_TAGS_EXIST: <<parameters.skip_when_tags_exist>>
       command: <<include(scripts/tag_image.sh)>>

--- a/src/scripts/create_repo.sh
+++ b/src/scripts/create_repo.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-ORB_STR_REGION="$(circleci env subst "${ORB_STR_REGION}")"
-ORB_STR_REPO="$(circleci env subst "${ORB_STR_REPO}")"
-ORB_STR_PROFILE_NAME="$(circleci env subst "${ORB_STR_PROFILE_NAME}")"
-ORB_STR_ENCRYPTION_KMS_KEY="$(circleci env subst "${ORB_STR_ENCRYPTION_KMS_KEY}")"
+ORB_EVAL_REGION="$(eval echo "${ORB_STR_REGION}")"
+ORB_EVAL_REPO="$(eval echo "${ORB_STR_REPO}")"
+ORB_EVAL_PROFILE_NAME="$(eval echo "${ORB_STR_PROFILE_NAME}")"
+ORB_EVAL_ENCRYPTION_KMS_KEY="$(eval echo "${ORB_STR_ENCRYPTION_KMS_KEY}")"
 
 if [ "$ORB_BOOL_PUBLIC_REGISTRY" == "1" ]; then
-    aws ecr-public describe-repositories --profile "${ORB_STR_PROFILE_NAME}" --region us-east-1 --repository-names "${ORB_STR_REPO}" >/dev/null 2>&1 ||
-        aws ecr-public create-repository --profile "${ORB_STR_PROFILE_NAME}" --region us-east-1 --repository-name "${ORB_STR_REPO}"
+    aws ecr-public describe-repositories --profile "${ORB_EVAL_PROFILE_NAME}" --region us-east-1 --repository-names "${ORB_EVAL_REPO}" >/dev/null 2>&1 ||
+        aws ecr-public create-repository --profile "${ORB_EVAL_PROFILE_NAME}" --region us-east-1 --repository-name "${ORB_EVAL_REPO}"
 else
 
     IMAGE_SCANNING_CONFIGURATION="scanOnPush=true"
@@ -16,17 +16,17 @@ else
 
     ENCRYPTION_CONFIGURATION="encryptionType=${ORB_ENUM_ENCRYPTION_TYPE}"
     if [ "$ORB_ENUM_ENCRYPTION_TYPE" == "KMS"  ]; then
-      ENCRYPTION_CONFIGURATION+=",kmsKey=${ORB_STR_ENCRYPTION_KMS_KEY}"
+      ENCRYPTION_CONFIGURATION+=",kmsKey=${ORB_EVAL_ENCRYPTION_KMS_KEY}"
     fi
 
     aws ecr describe-repositories \
-      --profile "${ORB_STR_PROFILE_NAME}" \
-      --region "${ORB_STR_REGION}" \
-      --repository-names "${ORB_STR_REPO}" >/dev/null 2>&1 ||
+      --profile "${ORB_EVAL_PROFILE_NAME}" \
+      --region "${ORB_EVAL_REGION}" \
+      --repository-names "${ORB_EVAL_REPO}" >/dev/null 2>&1 ||
         aws ecr create-repository \
-          --profile "${ORB_STR_PROFILE_NAME}" \
-          --region "${ORB_STR_REGION}" \
-          --repository-name "${ORB_STR_REPO}" \
+          --profile "${ORB_EVAL_PROFILE_NAME}" \
+          --region "${ORB_EVAL_REGION}" \
+          --repository-name "${ORB_EVAL_REPO}" \
           --image-scanning-configuration "${IMAGE_SCANNING_CONFIGURATION}" \
           --encryption-configuration "${ENCRYPTION_CONFIGURATION}"
 fi

--- a/src/scripts/create_repo.sh
+++ b/src/scripts/create_repo.sh
@@ -1,32 +1,32 @@
 #!/bin/bash
-ORB_EVAL_REGION="$(eval echo "${ORB_STR_REGION}")"
-ORB_EVAL_REPO="$(eval echo "${ORB_STR_REPO}")"
-ORB_EVAL_PROFILE_NAME="$(eval echo "${ORB_STR_PROFILE_NAME}")"
-ORB_EVAL_ENCRYPTION_KMS_KEY="$(eval echo "${ORB_STR_ENCRYPTION_KMS_KEY}")"
+AWS_ECR_EVAL_REGION="$(eval echo "${AWS_ECR_STR_REGION}")"
+AWS_ECR_EVAL_REPO="$(eval echo "${AWS_ECR_STR_REPO}")"
+AWS_ECR_EVAL_PROFILE_NAME="$(eval echo "${AWS_ECR_STR_PROFILE_NAME}")"
+AWS_ECR_EVAL_ENCRYPTION_KMS_KEY="$(eval echo "${AWS_ECR_STR_ENCRYPTION_KMS_KEY}")"
 
-if [ "$ORB_BOOL_PUBLIC_REGISTRY" == "1" ]; then
-    aws ecr-public describe-repositories --profile "${ORB_EVAL_PROFILE_NAME}" --region us-east-1 --repository-names "${ORB_EVAL_REPO}" >/dev/null 2>&1 ||
-        aws ecr-public create-repository --profile "${ORB_EVAL_PROFILE_NAME}" --region us-east-1 --repository-name "${ORB_EVAL_REPO}"
+if [ "$AWS_ECR_BOOL_PUBLIC_REGISTRY" == "1" ]; then
+    aws ecr-public describe-repositories --profile "${AWS_ECR_EVAL_PROFILE_NAME}" --region us-east-1 --repository-names "${AWS_ECR_EVAL_REPO}" >/dev/null 2>&1 ||
+        aws ecr-public create-repository --profile "${AWS_ECR_EVAL_PROFILE_NAME}" --region us-east-1 --repository-name "${AWS_ECR_EVAL_REPO}"
 else
 
     IMAGE_SCANNING_CONFIGURATION="scanOnPush=true"
-    if [ "$ORB_BOOL_REPO_SCAN_ON_PUSH" -ne "1" ]; then
+    if [ "$AWS_ECR_BOOL_REPO_SCAN_ON_PUSH" -ne "1" ]; then
       IMAGE_SCANNING_CONFIGURATION="scanOnPush=false"
     fi
 
-    ENCRYPTION_CONFIGURATION="encryptionType=${ORB_ENUM_ENCRYPTION_TYPE}"
-    if [ "$ORB_ENUM_ENCRYPTION_TYPE" == "KMS"  ]; then
-      ENCRYPTION_CONFIGURATION+=",kmsKey=${ORB_EVAL_ENCRYPTION_KMS_KEY}"
+    ENCRYPTION_CONFIGURATION="encryptionType=${AWS_ECR_ENUM_ENCRYPTION_TYPE}"
+    if [ "$AWS_ECR_ENUM_ENCRYPTION_TYPE" == "KMS"  ]; then
+      ENCRYPTION_CONFIGURATION+=",kmsKey=${AWS_ECR_EVAL_ENCRYPTION_KMS_KEY}"
     fi
 
     aws ecr describe-repositories \
-      --profile "${ORB_EVAL_PROFILE_NAME}" \
-      --region "${ORB_EVAL_REGION}" \
-      --repository-names "${ORB_EVAL_REPO}" >/dev/null 2>&1 ||
+      --profile "${AWS_ECR_EVAL_PROFILE_NAME}" \
+      --region "${AWS_ECR_EVAL_REGION}" \
+      --repository-names "${AWS_ECR_EVAL_REPO}" >/dev/null 2>&1 ||
         aws ecr create-repository \
-          --profile "${ORB_EVAL_PROFILE_NAME}" \
-          --region "${ORB_EVAL_REGION}" \
-          --repository-name "${ORB_EVAL_REPO}" \
+          --profile "${AWS_ECR_EVAL_PROFILE_NAME}" \
+          --region "${AWS_ECR_EVAL_REGION}" \
+          --repository-name "${AWS_ECR_EVAL_REPO}" \
           --image-scanning-configuration "${IMAGE_SCANNING_CONFIGURATION}" \
           --encryption-configuration "${ENCRYPTION_CONFIGURATION}"
 fi

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
-ORB_STR_REGION="$(circleci env subst "${ORB_STR_REGION}")"
-ORB_STR_REPO="$(circleci env subst "${ORB_STR_REPO}")"
-ORB_STR_TAG="$(circleci env subst "${ORB_STR_TAG}")"
+ORB_EVAL_REGION="$(eval echo "${ORB_STR_REGION}")"
+ORB_EVAL_REPO="$(eval echo "${ORB_STR_REPO}")"
+ORB_EVAL_TAG="$(eval echo "${ORB_STR_TAG}")"
 ORB_EVAL_PATH="$(eval echo "${ORB_EVAL_PATH}")"
 ORB_STR_AWS_DOMAIN="$(echo "${ORB_STR_AWS_DOMAIN}" | circleci env subst)"
-ORB_STR_ACCOUNT_ID="$(circleci env subst "${ORB_STR_ACCOUNT_ID}")"
-ORB_VAL_ACCOUNT_URL="${ORB_STR_ACCOUNT_ID}.dkr.ecr.${ORB_STR_REGION}.${ORB_STR_AWS_DOMAIN}"
-ORB_STR_PUBLIC_REGISTRY_ALIAS="$(circleci env subst "${ORB_STR_PUBLIC_REGISTRY_ALIAS}")"
+ORB_EVAL_ACCOUNT_ID="$(eval echo "${ORB_STR_ACCOUNT_ID}")"
+ORB_VAL_ACCOUNT_URL="${ORB_EVAL_ACCOUNT_ID}.dkr.ecr.${ORB_EVAL_REGION}.${ORB_STR_AWS_DOMAIN}"
+ORB_EVAL_PUBLIC_REGISTRY_ALIAS="$(eval echo "${ORB_STR_PUBLIC_REGISTRY_ALIAS}")"
 ORB_STR_EXTRA_BUILD_ARGS="$(echo "${ORB_STR_EXTRA_BUILD_ARGS}" | circleci env subst)"
 ORB_EVAL_BUILD_PATH="$(eval echo "${ORB_EVAL_BUILD_PATH}")"
-ORB_STR_DOCKERFILE="$(circleci env subst "${ORB_STR_DOCKERFILE}")"
-ORB_STR_PROFILE_NAME="$(circleci env subst "${ORB_STR_PROFILE_NAME}")"
-ORB_STR_PLATFORM="$(circleci env subst "${ORB_STR_PLATFORM}")"
-ORB_STR_LIFECYCLE_POLICY_PATH="$(circleci env subst "${ORB_STR_LIFECYCLE_POLICY_PATH}")"
+ORB_EVAL_DOCKERFILE="$(eval echo "${ORB_STR_DOCKERFILE}")"
+ORB_EVAL_PROFILE_NAME="$(eval echo "${ORB_STR_PROFILE_NAME}")"
+ORB_EVAL_PLATFORM="$(eval echo "${ORB_STR_PLATFORM}")"
+ORB_EVAL_LIFECYCLE_POLICY_PATH="$(eval echo "${ORB_STR_LIFECYCLE_POLICY_PATH}")"
 
 
 if [ -n "${ORB_STR_EXTRA_BUILD_ARGS}" ]; then
@@ -24,40 +24,40 @@ fi
 ECR_COMMAND="ecr"
 number_of_tags_in_ecr=0
 
-IFS=', ' read -ra platform <<<"${ORB_STR_PLATFORM}"
+IFS=', ' read -ra platform <<<"${ORB_EVAL_PLATFORM}"
 number_of_platforms="${#platform[@]}"
 
-if [ -z "${ORB_STR_ACCOUNT_ID}" ]; then
+if [ -z "${ORB_EVAL_ACCOUNT_ID}" ]; then
   echo "The account ID is not found. Please add the account ID before continuing."
   exit 1
 fi
 
 if [ "${ORB_BOOL_PUBLIC_REGISTRY}" -eq "1" ]; then
   ECR_COMMAND="ecr-public"
-  ORB_VAL_ACCOUNT_URL="public.ecr.aws/${ORB_STR_PUBLIC_REGISTRY_ALIAS}"
+  ORB_VAL_ACCOUNT_URL="public.ecr.aws/${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}"
 fi
 
-IFS="," read -ra DOCKER_TAGS <<<"${ORB_STR_TAG}"
+IFS="," read -ra DOCKER_TAGS <<<"${ORB_EVAL_TAG}"
 for tag in "${DOCKER_TAGS[@]}"; do
   if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "1" ] || [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" = "true" ]; then
-    docker_tag_exists_in_ecr=$(aws "${ECR_COMMAND}" describe-images --profile "${ORB_STR_PROFILE_NAME}" --registry-id "${ORB_STR_ACCOUNT_ID}" --region "${ORB_STR_REGION}" --repository-name "${ORB_STR_REPO}" --query "contains(imageDetails[].imageTags[], '${tag}')")
+    docker_tag_exists_in_ecr=$(aws "${ECR_COMMAND}" describe-images --profile "${ORB_EVAL_PROFILE_NAME}" --registry-id "${ORB_EVAL_ACCOUNT_ID}" --region "${ORB_EVAL_REGION}" --repository-name "${ORB_EVAL_REPO}" --query "contains(imageDetails[].imageTags[], '${tag}')")
     if [ "${docker_tag_exists_in_ecr}" = "true" ]; then
-      docker pull "${ORB_VAL_ACCOUNT_URL}/${ORB_STR_REPO}:${tag}"
+      docker pull "${ORB_VAL_ACCOUNT_URL}/${ORB_EVAL_REPO}:${tag}"
       number_of_tags_in_ecr=$((number_of_tags_in_ecr += 1))
     fi
   fi
-  docker_tag_args="${docker_tag_args} -t ${ORB_VAL_ACCOUNT_URL}/${ORB_STR_REPO}:${tag}"
+  docker_tag_args="${docker_tag_args} -t ${ORB_VAL_ACCOUNT_URL}/${ORB_EVAL_REPO}:${tag}"
 done
 
 if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "0" ] || [[ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "1" && ${number_of_tags_in_ecr} -lt ${#DOCKER_TAGS[@]} ]]; then
   if [ "${ORB_BOOL_PUSH_IMAGE}" -eq "1" ]; then
     set -- "$@" --push
 
-    if [ -n "${ORB_STR_LIFECYCLE_POLICY_PATH}" ]; then
+    if [ -n "${ORB_EVAL_LIFECYCLE_POLICY_PATH}" ]; then
       aws ecr put-lifecycle-policy \
-        --profile "${ORB_STR_PROFILE_NAME}" \
-        --repository-name "${ORB_STR_REPO}" \
-        --lifecycle-policy-text "file://${ORB_STR_LIFECYCLE_POLICY_PATH}"
+        --profile "${ORB_EVAL_PROFILE_NAME}" \
+        --repository-name "${ORB_EVAL_REPO}" \
+        --lifecycle-policy-text "file://${ORB_EVAL_LIFECYCLE_POLICY_PATH}"
     fi
 
   elif [ "${ORB_BOOL_PUSH_IMAGE}" -eq "0" ] && [ "${number_of_platforms}" -le 1 ];then
@@ -76,20 +76,20 @@ if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "0" ] || [[ "${ORB_BOOL_SKIP_WHEN_TA
     fi
     context_args="--context builder"
   # if no builder instance is currently used, create one
-  elif ! docker buildx inspect | grep -q "default * docker"; then 
-    docker buildx create --name DLC_builder --use 
-  fi 
+  elif ! docker buildx inspect | grep -q "default * docker"; then
+    docker buildx create --name DLC_builder --use
+  fi
 
 set -x
   docker \
     ${context_args:+$context_args} \
     buildx build \
-    -f "${ORB_EVAL_PATH}"/"${ORB_STR_DOCKERFILE}" \
+    -f "${ORB_EVAL_PATH}"/"${ORB_EVAL_DOCKERFILE}" \
     ${docker_tag_args:+$docker_tag_args} \
-    --platform "${ORB_STR_PLATFORM}" \
+    --platform "${ORB_EVAL_PLATFORM}" \
     --progress plain \
     "$@" \
     "${ORB_EVAL_BUILD_PATH}"
 set +x
-  
+
 fi

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
-ORB_EVAL_REGION="$(eval echo "${ORB_STR_REGION}")"
-ORB_EVAL_REPO="$(eval echo "${ORB_STR_REPO}")"
-ORB_EVAL_TAG="$(eval echo "${ORB_STR_TAG}")"
-ORB_EVAL_PATH="$(eval echo "${ORB_EVAL_PATH}")"
-ORB_STR_AWS_DOMAIN="$(echo "${ORB_STR_AWS_DOMAIN}" | circleci env subst)"
-ORB_EVAL_ACCOUNT_ID="$(eval echo "${ORB_STR_ACCOUNT_ID}")"
-ORB_VAL_ACCOUNT_URL="${ORB_EVAL_ACCOUNT_ID}.dkr.ecr.${ORB_EVAL_REGION}.${ORB_STR_AWS_DOMAIN}"
-ORB_EVAL_PUBLIC_REGISTRY_ALIAS="$(eval echo "${ORB_STR_PUBLIC_REGISTRY_ALIAS}")"
-ORB_STR_EXTRA_BUILD_ARGS="$(echo "${ORB_STR_EXTRA_BUILD_ARGS}" | circleci env subst)"
-ORB_EVAL_BUILD_PATH="$(eval echo "${ORB_EVAL_BUILD_PATH}")"
-ORB_EVAL_DOCKERFILE="$(eval echo "${ORB_STR_DOCKERFILE}")"
-ORB_EVAL_PROFILE_NAME="$(eval echo "${ORB_STR_PROFILE_NAME}")"
-ORB_EVAL_PLATFORM="$(eval echo "${ORB_STR_PLATFORM}")"
-ORB_EVAL_LIFECYCLE_POLICY_PATH="$(eval echo "${ORB_STR_LIFECYCLE_POLICY_PATH}")"
+AWS_ECR_EVAL_REGION="$(eval echo "${AWS_ECR_STR_REGION}")"
+AWS_ECR_EVAL_REPO="$(eval echo "${AWS_ECR_STR_REPO}")"
+AWS_ECR_EVAL_TAG="$(eval echo "${AWS_ECR_STR_TAG}")"
+AWS_ECR_EVAL_PATH="$(eval echo "${AWS_ECR_EVAL_PATH}")"
+AWS_ECR_STR_AWS_DOMAIN="$(echo "${AWS_ECR_STR_AWS_DOMAIN}" | circleci env subst)"
+AWS_ECR_EVAL_ACCOUNT_ID="$(eval echo "${AWS_ECR_STR_ACCOUNT_ID}")"
+AWS_ECR_VAL_ACCOUNT_URL="${AWS_ECR_EVAL_ACCOUNT_ID}.dkr.ecr.${AWS_ECR_EVAL_REGION}.${AWS_ECR_STR_AWS_DOMAIN}"
+AWS_ECR_EVAL_PUBLIC_REGISTRY_ALIAS="$(eval echo "${AWS_ECR_STR_PUBLIC_REGISTRY_ALIAS}")"
+AWS_ECR_STR_EXTRA_BUILD_ARGS="$(echo "${AWS_ECR_STR_EXTRA_BUILD_ARGS}" | circleci env subst)"
+AWS_ECR_EVAL_BUILD_PATH="$(eval echo "${AWS_ECR_EVAL_BUILD_PATH}")"
+AWS_ECR_EVAL_DOCKERFILE="$(eval echo "${AWS_ECR_STR_DOCKERFILE}")"
+AWS_ECR_EVAL_PROFILE_NAME="$(eval echo "${AWS_ECR_STR_PROFILE_NAME}")"
+AWS_ECR_EVAL_PLATFORM="$(eval echo "${AWS_ECR_STR_PLATFORM}")"
+AWS_ECR_EVAL_LIFECYCLE_POLICY_PATH="$(eval echo "${AWS_ECR_STR_LIFECYCLE_POLICY_PATH}")"
 
 
-if [ -n "${ORB_STR_EXTRA_BUILD_ARGS}" ]; then
-  IFS=" " read -a args -r <<< "${ORB_STR_EXTRA_BUILD_ARGS[@]}"
+if [ -n "${AWS_ECR_STR_EXTRA_BUILD_ARGS}" ]; then
+  IFS=" " read -a args -r <<< "${AWS_ECR_STR_EXTRA_BUILD_ARGS[@]}"
   for arg in "${args[@]}"; do
     set -- "$@" "$arg"
   done
@@ -24,43 +24,43 @@ fi
 ECR_COMMAND="ecr"
 number_of_tags_in_ecr=0
 
-IFS=', ' read -ra platform <<<"${ORB_EVAL_PLATFORM}"
+IFS=', ' read -ra platform <<<"${AWS_ECR_EVAL_PLATFORM}"
 number_of_platforms="${#platform[@]}"
 
-if [ -z "${ORB_EVAL_ACCOUNT_ID}" ]; then
+if [ -z "${AWS_ECR_EVAL_ACCOUNT_ID}" ]; then
   echo "The account ID is not found. Please add the account ID before continuing."
   exit 1
 fi
 
-if [ "${ORB_BOOL_PUBLIC_REGISTRY}" -eq "1" ]; then
+if [ "${AWS_ECR_BOOL_PUBLIC_REGISTRY}" -eq "1" ]; then
   ECR_COMMAND="ecr-public"
-  ORB_VAL_ACCOUNT_URL="public.ecr.aws/${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}"
+  AWS_ECR_VAL_ACCOUNT_URL="public.ecr.aws/${AWS_ECR_EVAL_PUBLIC_REGISTRY_ALIAS}"
 fi
 
-IFS="," read -ra DOCKER_TAGS <<<"${ORB_EVAL_TAG}"
+IFS="," read -ra DOCKER_TAGS <<<"${AWS_ECR_EVAL_TAG}"
 for tag in "${DOCKER_TAGS[@]}"; do
-  if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "1" ] || [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" = "true" ]; then
-    docker_tag_exists_in_ecr=$(aws "${ECR_COMMAND}" describe-images --profile "${ORB_EVAL_PROFILE_NAME}" --registry-id "${ORB_EVAL_ACCOUNT_ID}" --region "${ORB_EVAL_REGION}" --repository-name "${ORB_EVAL_REPO}" --query "contains(imageDetails[].imageTags[], '${tag}')")
+  if [ "${AWS_ECR_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "1" ] || [ "${AWS_ECR_BOOL_SKIP_WHEN_TAGS_EXIST}" = "true" ]; then
+    docker_tag_exists_in_ecr=$(aws "${ECR_COMMAND}" describe-images --profile "${AWS_ECR_EVAL_PROFILE_NAME}" --registry-id "${AWS_ECR_EVAL_ACCOUNT_ID}" --region "${AWS_ECR_EVAL_REGION}" --repository-name "${AWS_ECR_EVAL_REPO}" --query "contains(imageDetails[].imageTags[], '${tag}')")
     if [ "${docker_tag_exists_in_ecr}" = "true" ]; then
-      docker pull "${ORB_VAL_ACCOUNT_URL}/${ORB_EVAL_REPO}:${tag}"
+      docker pull "${AWS_ECR_VAL_ACCOUNT_URL}/${AWS_ECR_EVAL_REPO}:${tag}"
       number_of_tags_in_ecr=$((number_of_tags_in_ecr += 1))
     fi
   fi
-  docker_tag_args="${docker_tag_args} -t ${ORB_VAL_ACCOUNT_URL}/${ORB_EVAL_REPO}:${tag}"
+  docker_tag_args="${docker_tag_args} -t ${AWS_ECR_VAL_ACCOUNT_URL}/${AWS_ECR_EVAL_REPO}:${tag}"
 done
 
-if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "0" ] || [[ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "1" && ${number_of_tags_in_ecr} -lt ${#DOCKER_TAGS[@]} ]]; then
-  if [ "${ORB_BOOL_PUSH_IMAGE}" -eq "1" ]; then
+if [ "${AWS_ECR_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "0" ] || [[ "${AWS_ECR_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "1" && ${number_of_tags_in_ecr} -lt ${#DOCKER_TAGS[@]} ]]; then
+  if [ "${AWS_ECR_BOOL_PUSH_IMAGE}" -eq "1" ]; then
     set -- "$@" --push
 
-    if [ -n "${ORB_EVAL_LIFECYCLE_POLICY_PATH}" ]; then
+    if [ -n "${AWS_ECR_EVAL_LIFECYCLE_POLICY_PATH}" ]; then
       aws ecr put-lifecycle-policy \
-        --profile "${ORB_EVAL_PROFILE_NAME}" \
-        --repository-name "${ORB_EVAL_REPO}" \
-        --lifecycle-policy-text "file://${ORB_EVAL_LIFECYCLE_POLICY_PATH}"
+        --profile "${AWS_ECR_EVAL_PROFILE_NAME}" \
+        --repository-name "${AWS_ECR_EVAL_REPO}" \
+        --lifecycle-policy-text "file://${AWS_ECR_EVAL_LIFECYCLE_POLICY_PATH}"
     fi
 
-  elif [ "${ORB_BOOL_PUSH_IMAGE}" -eq "0" ] && [ "${number_of_platforms}" -le 1 ];then
+  elif [ "${AWS_ECR_BOOL_PUSH_IMAGE}" -eq "0" ] && [ "${number_of_platforms}" -le 1 ];then
     set -- "$@" --load
   fi
 
@@ -84,12 +84,12 @@ set -x
   docker \
     ${context_args:+$context_args} \
     buildx build \
-    -f "${ORB_EVAL_PATH}"/"${ORB_EVAL_DOCKERFILE}" \
+    -f "${AWS_ECR_EVAL_PATH}"/"${AWS_ECR_EVAL_DOCKERFILE}" \
     ${docker_tag_args:+$docker_tag_args} \
-    --platform "${ORB_EVAL_PLATFORM}" \
+    --platform "${AWS_ECR_EVAL_PLATFORM}" \
     --progress plain \
     "$@" \
-    "${ORB_EVAL_BUILD_PATH}"
+    "${AWS_ECR_EVAL_BUILD_PATH}"
 set +x
 
 fi

--- a/src/scripts/ecr_login.sh
+++ b/src/scripts/ecr_login.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
-ORB_STR_REGION="$(circleci env subst "${ORB_STR_REGION}")"
-ORB_STR_PROFILE_NAME="$(circleci env subst "${ORB_STR_PROFILE_NAME}")"
-ORB_STR_ACCOUNT_ID="$(circleci env subst "${ORB_STR_ACCOUNT_ID}")"
-ORB_VAL_ACCOUNT_URL="${ORB_STR_ACCOUNT_ID}.dkr.ecr.${ORB_STR_REGION}.${ORB_STR_AWS_DOMAIN}"
+ORB_EVAL_REGION="$(eval echo "${ORB_STR_REGION}")"
+ORB_EVAL_PROFILE_NAME="$(eval echo "${ORB_STR_PROFILE_NAME}")"
+ORB_EVAL_ACCOUNT_ID="$(eval echo "${ORB_STR_ACCOUNT_ID}")"
+ORB_VAL_ACCOUNT_URL="${ORB_EVAL_ACCOUNT_ID}.dkr.ecr.${ORB_EVAL_REGION}.${ORB_STR_AWS_DOMAIN}"
 ECR_COMMAND="ecr"
 
-if [ -z "${ORB_STR_ACCOUNT_ID}" ]; then
+if [ -z "${ORB_EVAL_ACCOUNT_ID}" ]; then
   echo "The account ID is not found. Please add the account ID before continuing."
   exit 1
 fi
 
 if [ "$ORB_BOOL_PUBLIC_REGISTRY" == "1" ]; then
-    ORB_STR_REGION="us-east-1"
+    ORB_EVAL_REGION="us-east-1"
     ORB_VAL_ACCOUNT_URL="public.ecr.aws"
     ECR_COMMAND="ecr-public"
 fi
 
-if [ -n "${ORB_STR_PROFILE_NAME}" ]; then
-    set -- "$@" --profile "${ORB_STR_PROFILE_NAME}"
+if [ -n "${ORB_EVAL_PROFILE_NAME}" ]; then
+    set -- "$@" --profile "${ORB_EVAL_PROFILE_NAME}"
 fi
 
 if [ -f "$HOME/.docker/config.json" ] && grep "${ORB_VAL_ACCOUNT_URL}" < ~/.docker/config.json > /dev/null 2>&1 ; then
     echo "Credential helper is already installed"
 else
-    docker logout "${ORB_VAL_ACCOUNT_URL}"    
-    aws "${ECR_COMMAND}" get-login-password --region "${ORB_STR_REGION}" "$@" | docker login --username AWS --password-stdin "${ORB_VAL_ACCOUNT_URL}"
+    docker logout "${ORB_VAL_ACCOUNT_URL}"
+    aws "${ECR_COMMAND}" get-login-password --region "${ORB_EVAL_REGION}" "$@" | docker login --username AWS --password-stdin "${ORB_VAL_ACCOUNT_URL}"
 fi

--- a/src/scripts/ecr_login.sh
+++ b/src/scripts/ecr_login.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
-ORB_EVAL_REGION="$(eval echo "${ORB_STR_REGION}")"
-ORB_EVAL_PROFILE_NAME="$(eval echo "${ORB_STR_PROFILE_NAME}")"
-ORB_EVAL_ACCOUNT_ID="$(eval echo "${ORB_STR_ACCOUNT_ID}")"
-ORB_VAL_ACCOUNT_URL="${ORB_EVAL_ACCOUNT_ID}.dkr.ecr.${ORB_EVAL_REGION}.${ORB_STR_AWS_DOMAIN}"
+AWS_ECR_EVAL_REGION="$(eval echo "${AWS_ECR_STR_REGION}")"
+AWS_ECR_EVAL_PROFILE_NAME="$(eval echo "${AWS_ECR_STR_PROFILE_NAME}")"
+AWS_ECR_EVAL_ACCOUNT_ID="$(eval echo "${AWS_ECR_STR_ACCOUNT_ID}")"
+AWS_ECR_VAL_ACCOUNT_URL="${AWS_ECR_EVAL_ACCOUNT_ID}.dkr.ecr.${AWS_ECR_EVAL_REGION}.${AWS_ECR_STR_AWS_DOMAIN}"
 ECR_COMMAND="ecr"
 
-if [ -z "${ORB_EVAL_ACCOUNT_ID}" ]; then
+if [ -z "${AWS_ECR_EVAL_ACCOUNT_ID}" ]; then
   echo "The account ID is not found. Please add the account ID before continuing."
   exit 1
 fi
 
-if [ "$ORB_BOOL_PUBLIC_REGISTRY" == "1" ]; then
-    ORB_EVAL_REGION="us-east-1"
-    ORB_VAL_ACCOUNT_URL="public.ecr.aws"
+if [ "$AWS_ECR_BOOL_PUBLIC_REGISTRY" == "1" ]; then
+    AWS_ECR_EVAL_REGION="us-east-1"
+    AWS_ECR_VAL_ACCOUNT_URL="public.ecr.aws"
     ECR_COMMAND="ecr-public"
 fi
 
-if [ -n "${ORB_EVAL_PROFILE_NAME}" ]; then
-    set -- "$@" --profile "${ORB_EVAL_PROFILE_NAME}"
+if [ -n "${AWS_ECR_EVAL_PROFILE_NAME}" ]; then
+    set -- "$@" --profile "${AWS_ECR_EVAL_PROFILE_NAME}"
 fi
 
-if [ -f "$HOME/.docker/config.json" ] && grep "${ORB_VAL_ACCOUNT_URL}" < ~/.docker/config.json > /dev/null 2>&1 ; then
+if [ -f "$HOME/.docker/config.json" ] && grep "${AWS_ECR_VAL_ACCOUNT_URL}" < ~/.docker/config.json > /dev/null 2>&1 ; then
     echo "Credential helper is already installed"
 else
-    docker logout "${ORB_VAL_ACCOUNT_URL}"
-    aws "${ECR_COMMAND}" get-login-password --region "${ORB_EVAL_REGION}" "$@" | docker login --username AWS --password-stdin "${ORB_VAL_ACCOUNT_URL}"
+    docker logout "${AWS_ECR_VAL_ACCOUNT_URL}"
+    aws "${ECR_COMMAND}" get-login-password --region "${AWS_ECR_EVAL_REGION}" "$@" | docker login --username AWS --password-stdin "${AWS_ECR_VAL_ACCOUNT_URL}"
 fi

--- a/src/scripts/push_image.sh
+++ b/src/scripts/push_image.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
-ORB_EVAL_REPO="$(eval echo "${ORB_STR_REPO}")"
-ORB_EVAL_TAG="$(eval echo "${ORB_STR_TAG}")"
-ORB_EVAL_REGION="$(eval echo "${ORB_STR_REGION}")"
-ORB_EVAL_ACCOUNT_ID="$(eval echo "${ORB_STR_ACCOUNT_ID}")"
-ORB_VAL_ACCOUNT_URL="${ORB_EVAL_ACCOUNT_ID}.dkr.ecr.${ORB_EVAL_REGION}.amazonaws.com"
-ORB_EVAL_PUBLIC_REGISTRY_ALIAS="$(eval echo "${ORB_STR_PUBLIC_REGISTRY_ALIAS}")"
+AWS_ECR_EVAL_REPO="$(eval echo "${AWS_ECR_STR_REPO}")"
+AWS_ECR_EVAL_TAG="$(eval echo "${AWS_ECR_STR_TAG}")"
+AWS_ECR_EVAL_REGION="$(eval echo "${AWS_ECR_STR_REGION}")"
+AWS_ECR_EVAL_ACCOUNT_ID="$(eval echo "${AWS_ECR_STR_ACCOUNT_ID}")"
+AWS_ECR_VAL_ACCOUNT_URL="${AWS_ECR_EVAL_ACCOUNT_ID}.dkr.ecr.${AWS_ECR_EVAL_REGION}.amazonaws.com"
+AWS_ECR_EVAL_PUBLIC_REGISTRY_ALIAS="$(eval echo "${AWS_ECR_STR_PUBLIC_REGISTRY_ALIAS}")"
 
-echo "$ORB_VAL_ACCOUNT_URL" >> test.txt
+echo "$AWS_ECR_VAL_ACCOUNT_URL" >> test.txt
 
-if [ -z "${ORB_EVAL_ACCOUNT_ID}" ]; then
+if [ -z "${AWS_ECR_EVAL_ACCOUNT_ID}" ]; then
   echo "The account ID is not found. Please add the account ID before continuing."
   exit 1
 fi
 
-if [ "${ORB_BOOL_PUBLIC_REGISTRY}" == "1" ]; then
-  ORB_VAL_ACCOUNT_URL="public.ecr.aws/${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}"
+if [ "${AWS_ECR_BOOL_PUBLIC_REGISTRY}" == "1" ]; then
+  AWS_ECR_VAL_ACCOUNT_URL="public.ecr.aws/${AWS_ECR_EVAL_PUBLIC_REGISTRY_ALIAS}"
 fi
 
-IFS="," read -ra DOCKER_TAGS <<< "${ORB_EVAL_TAG}"
+IFS="," read -ra DOCKER_TAGS <<< "${AWS_ECR_EVAL_TAG}"
 for tag in "${DOCKER_TAGS[@]}"; do
 set -x
-    docker push "${ORB_VAL_ACCOUNT_URL}/${ORB_EVAL_REPO}:${tag}"
+    docker push "${AWS_ECR_VAL_ACCOUNT_URL}/${AWS_ECR_EVAL_REPO}:${tag}"
 set +x
 done

--- a/src/scripts/push_image.sh
+++ b/src/scripts/push_image.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
-set -x
 ORB_EVAL_REPO="$(eval echo "${ORB_STR_REPO}")"
 ORB_EVAL_TAG="$(eval echo "${ORB_STR_TAG}")"
 ORB_EVAL_REGION="$(eval echo "${ORB_STR_REGION}")"
 ORB_EVAL_ACCOUNT_ID="$(eval echo "${ORB_STR_ACCOUNT_ID}")"
-ORB_VAL_ACCOUNT_URL="${ORB_EVAL_ACCOUNT_ID}.dkr.ecr.${ORB_EVAL_REGION}"
+ORB_VAL_ACCOUNT_URL="${ORB_EVAL_ACCOUNT_ID}.dkr.ecr.${ORB_EVAL_REGION}.amazonaws.com"
 ORB_EVAL_PUBLIC_REGISTRY_ALIAS="$(eval echo "${ORB_STR_PUBLIC_REGISTRY_ALIAS}")"
 
 echo "$ORB_VAL_ACCOUNT_URL" >> test.txt
@@ -20,8 +19,7 @@ fi
 
 IFS="," read -ra DOCKER_TAGS <<< "${ORB_EVAL_TAG}"
 for tag in "${DOCKER_TAGS[@]}"; do
+set -x
     docker push "${ORB_VAL_ACCOUNT_URL}/${ORB_EVAL_REPO}:${tag}"
-done
-
-docker image ls >> test.txt
 set +x
+done

--- a/src/scripts/push_image.sh
+++ b/src/scripts/push_image.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
-ORB_STR_REPO="$(circleci env subst "${ORB_STR_REPO}")"
-ORB_STR_TAG="$(circleci env subst "${ORB_STR_TAG}")"
-ORB_STR_REGION="$(circleci env subst "${ORB_STR_REGION}")"
-ORB_STR_ACCOUNT_ID="$(circleci env subst "${ORB_STR_ACCOUNT_ID}")"
-ORB_VAL_ACCOUNT_URL="${ORB_STR_ACCOUNT_ID}.dkr.ecr.${ORB_STR_REGION}.${ORB_STR_AWS_DOMAIN}"
-ORB_STR_PUBLIC_REGISTRY_ALIAS="$(circleci env subst "${ORB_STR_PUBLIC_REGISTRY_ALIAS}")"
+ORB_EVAL_REPO="$(eval echo "${ORB_STR_REPO}")"
+ORB_EVAL_TAG="$(eval echo "${ORB_STR_TAG}")"
+ORB_EVAL_REGION="$(eval echo "${ORB_STR_REGION}")"
+ORB_EVAL_ACCOUNT_ID="$(eval echo "${ORB_STR_ACCOUNT_ID}")"
+ORB_VAL_ACCOUNT_URL="${ORB_EVAL_ACCOUNT_ID}.dkr.ecr.${ORB_EVAL_REGION}.${ORB_EVAL_AWS_DOMAIN}"
+ORB_EVAL_PUBLIC_REGISTRY_ALIAS="$(eval echo "${ORB_STR_PUBLIC_REGISTRY_ALIAS}")"
 
-if [ -z "${ORB_STR_ACCOUNT_ID}" ]; then
+if [ -z "${ORB_EVAL_ACCOUNT_ID}" ]; then
   echo "The account ID is not found. Please add the account ID before continuing."
   exit 1
 fi
 
 if [ "${ORB_BOOL_PUBLIC_REGISTRY}" == "1" ]; then
-  ORB_VAL_ACCOUNT_URL="public.ecr.aws/${ORB_STR_PUBLIC_REGISTRY_ALIAS}"
+  ORB_VAL_ACCOUNT_URL="public.ecr.aws/${ORB_EVAL_PUBLIC_REGISTRY_ALIAS}"
 fi
 
-IFS="," read -ra DOCKER_TAGS <<< "${ORB_STR_TAG}"
+IFS="," read -ra DOCKER_TAGS <<< "${ORB_EVAL_TAG}"
 for tag in "${DOCKER_TAGS[@]}"; do
-    docker push "${ORB_VAL_ACCOUNT_URL}/${ORB_STR_REPO}:${tag}"
+    docker push "${ORB_VAL_ACCOUNT_URL}/${ORB_EVAL_REPO}:${tag}"
 done

--- a/src/scripts/push_image.sh
+++ b/src/scripts/push_image.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
+set -x
 ORB_EVAL_REPO="$(eval echo "${ORB_STR_REPO}")"
 ORB_EVAL_TAG="$(eval echo "${ORB_STR_TAG}")"
 ORB_EVAL_REGION="$(eval echo "${ORB_STR_REGION}")"
 ORB_EVAL_ACCOUNT_ID="$(eval echo "${ORB_STR_ACCOUNT_ID}")"
-ORB_VAL_ACCOUNT_URL="${ORB_EVAL_ACCOUNT_ID}.dkr.ecr.${ORB_EVAL_REGION}.${ORB_EVAL_AWS_DOMAIN}"
+ORB_VAL_ACCOUNT_URL="${ORB_EVAL_ACCOUNT_ID}.dkr.ecr.${ORB_EVAL_REGION}"
 ORB_EVAL_PUBLIC_REGISTRY_ALIAS="$(eval echo "${ORB_STR_PUBLIC_REGISTRY_ALIAS}")"
+
+echo "$ORB_VAL_ACCOUNT_URL" >> test.txt
 
 if [ -z "${ORB_EVAL_ACCOUNT_ID}" ]; then
   echo "The account ID is not found. Please add the account ID before continuing."
@@ -19,3 +22,6 @@ IFS="," read -ra DOCKER_TAGS <<< "${ORB_EVAL_TAG}"
 for tag in "${DOCKER_TAGS[@]}"; do
     docker push "${ORB_VAL_ACCOUNT_URL}/${ORB_EVAL_REPO}:${tag}"
 done
+
+docker image ls >> test.txt
+set +x

--- a/src/scripts/set_repo_policy.sh
+++ b/src/scripts/set_repo_policy.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
-ORB_EVAL_REGION="$(eval echo "${ORB_STR_REGION}")"
-ORB_EVAL_REPO="$(eval echo "${ORB_STR_REPO}")"
-ORB_EVAL_PROFILE_NAME="$(eval echo "${ORB_STR_PROFILE_NAME}")"
-ORB_EVAL_REPO_POLICY_PATH="$(eval echo "${ORB_STR_REPO_POLICY_PATH}")"
+AWS_ECR_EVAL_REGION="$(eval echo "${AWS_ECR_STR_REGION}")"
+AWS_ECR_EVAL_REPO="$(eval echo "${AWS_ECR_STR_REPO}")"
+AWS_ECR_EVAL_PROFILE_NAME="$(eval echo "${AWS_ECR_STR_PROFILE_NAME}")"
+AWS_ECR_EVAL_REPO_POLICY_PATH="$(eval echo "${AWS_ECR_STR_REPO_POLICY_PATH}")"
 
-if [ "$ORB_BOOL_PUBLIC_REGISTRY" == "1" ]; then
+if [ "$AWS_ECR_BOOL_PUBLIC_REGISTRY" == "1" ]; then
     echo "set-repository-policy is not supported on public repos"
     exit 1
 else
     aws ecr set-repository-policy \
-        --profile "${ORB_EVAL_PROFILE_NAME}" \
-        --region "${ORB_EVAL_REGION}" \
-        --repository-name "${ORB_EVAL_REPO}" \
-        --policy-text "file://${ORB_EVAL_REPO_POLICY_PATH}"
+        --profile "${AWS_ECR_EVAL_PROFILE_NAME}" \
+        --region "${AWS_ECR_EVAL_REGION}" \
+        --repository-name "${AWS_ECR_EVAL_REPO}" \
+        --policy-text "file://${AWS_ECR_EVAL_REPO_POLICY_PATH}"
 fi

--- a/src/scripts/set_repo_policy.sh
+++ b/src/scripts/set_repo_policy.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
-ORB_STR_REGION="$(circleci env subst "${ORB_STR_REGION}")"
-ORB_STR_REPO="$(circleci env subst "${ORB_STR_REPO}")"
-ORB_STR_PROFILE_NAME="$(circleci env subst "${ORB_STR_PROFILE_NAME}")"
-ORB_STR_REPO_POLICY_PATH="$(circleci env subst "${ORB_STR_REPO_POLICY_PATH}")"
+ORB_EVAL_REGION="$(eval echo "${ORB_STR_REGION}")"
+ORB_EVAL_REPO="$(eval echo "${ORB_STR_REPO}")"
+ORB_EVAL_PROFILE_NAME="$(eval echo "${ORB_STR_PROFILE_NAME}")"
+ORB_EVAL_REPO_POLICY_PATH="$(eval echo "${ORB_STR_REPO_POLICY_PATH}")"
 
 if [ "$ORB_BOOL_PUBLIC_REGISTRY" == "1" ]; then
     echo "set-repository-policy is not supported on public repos"
     exit 1
 else
     aws ecr set-repository-policy \
-        --profile "${ORB_STR_PROFILE_NAME}" \
-        --region "${ORB_STR_REGION}" \
-        --repository-name "${ORB_STR_REPO}" \
-        --policy-text "file://${ORB_STR_REPO_POLICY_PATH}"
+        --profile "${ORB_EVAL_PROFILE_NAME}" \
+        --region "${ORB_EVAL_REGION}" \
+        --repository-name "${ORB_EVAL_REPO}" \
+        --policy-text "file://${ORB_EVAL_REPO_POLICY_PATH}"
 fi

--- a/src/scripts/tag_image.sh
+++ b/src/scripts/tag_image.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
-ORB_EVAL_REPO="$(eval echo "${ORB_STR_REPO}")"
-ORB_EVAL_SOURCE_TAG="$(eval echo "${ORB_STR_SOURCE_TAG}")"
-ORB_EVAL_TARGET_TAG="$(eval echo "${ORB_STR_TARGET_TAG}")"
+AWS_ECR_EVAL_REPO="$(eval echo "${AWS_ECR_STR_REPO}")"
+AWS_ECR_EVAL_SOURCE_TAG="$(eval echo "${AWS_ECR_STR_SOURCE_TAG}")"
+AWS_ECR_EVAL_TARGET_TAG="$(eval echo "${AWS_ECR_STR_TARGET_TAG}")"
 
 # pull the image manifest from ECR
 set -x
-MANIFEST="$(aws ecr batch-get-image --repository-name "${ORB_EVAL_REPO}" --image-ids imageTag="${ORB_EVAL_SOURCE_TAG}" --query 'images[].imageManifest' --output text)"
-EXISTING_TAGS="$(aws ecr list-images --repository-name "${ORB_EVAL_REPO}" --filter "tagStatus=TAGGED")"
-IFS="," read -ra ECR_TAGS <<<"${ORB_EVAL_TARGET_TAG}"
+MANIFEST="$(aws ecr batch-get-image --repository-name "${AWS_ECR_EVAL_REPO}" --image-ids imageTag="${AWS_ECR_EVAL_SOURCE_TAG}" --query 'images[].imageManifest' --output text)"
+EXISTING_TAGS="$(aws ecr list-images --repository-name "${AWS_ECR_EVAL_REPO}" --filter "tagStatus=TAGGED")"
+IFS="," read -ra ECR_TAGS <<<"${AWS_ECR_EVAL_TARGET_TAG}"
 
 for tag in "${ECR_TAGS[@]}"; do
     # if skip_when_tags_exist is true
-    if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq 1 ]; then
+    if [ "${AWS_ECR_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq 1 ]; then
         # tag image if tag does not exist
         if ! echo "${EXISTING_TAGS}" | grep "${tag}"; then
-            aws ecr put-image --repository-name "${ORB_EVAL_REPO}" --image-tag "${tag}" --image-manifest "${MANIFEST}"
+            aws ecr put-image --repository-name "${AWS_ECR_EVAL_REPO}" --image-tag "${tag}" --image-manifest "${MANIFEST}"
         else
             echo "Tag \"${tag}\" already exists and will be skipped."
         fi
     # tag image when skip_when_tags_exist is false
     else
-        aws ecr put-image --repository-name "${ORB_EVAL_REPO}" --image-tag "${tag}" --image-manifest "${MANIFEST}"
+        aws ecr put-image --repository-name "${AWS_ECR_EVAL_REPO}" --image-tag "${tag}" --image-manifest "${MANIFEST}"
     fi
 done
 set +x

--- a/src/scripts/tag_image.sh
+++ b/src/scripts/tag_image.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
-ORB_STR_REPO="$(circleci env subst "${ORB_STR_REPO}")"
-ORB_STR_SOURCE_TAG="$(circleci env subst "${ORB_STR_SOURCE_TAG}")"
-ORB_STR_TARGET_TAG="$(circleci env subst "${ORB_STR_TARGET_TAG}")"
+ORB_EVAL_REPO="$(eval echo "${ORB_STR_REPO}")"
+ORB_EVAL_SOURCE_TAG="$(eval echo "${ORB_STR_SOURCE_TAG}")"
+ORB_EVAL_TARGET_TAG="$(eval echo "${ORB_STR_TARGET_TAG}")"
 
 # pull the image manifest from ECR
 set -x
-MANIFEST="$(aws ecr batch-get-image --repository-name "${ORB_STR_REPO}" --image-ids imageTag="${ORB_STR_SOURCE_TAG}" --query 'images[].imageManifest' --output text)"
-EXISTING_TAGS="$(aws ecr list-images --repository-name "${ORB_STR_REPO}" --filter "tagStatus=TAGGED")"
-IFS="," read -ra ECR_TAGS <<<"${ORB_STR_TARGET_TAG}"
+MANIFEST="$(aws ecr batch-get-image --repository-name "${ORB_EVAL_REPO}" --image-ids imageTag="${ORB_EVAL_SOURCE_TAG}" --query 'images[].imageManifest' --output text)"
+EXISTING_TAGS="$(aws ecr list-images --repository-name "${ORB_EVAL_REPO}" --filter "tagStatus=TAGGED")"
+IFS="," read -ra ECR_TAGS <<<"${ORB_EVAL_TARGET_TAG}"
 
 for tag in "${ECR_TAGS[@]}"; do
     # if skip_when_tags_exist is true
     if [ "${ORB_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq 1 ]; then
         # tag image if tag does not exist
         if ! echo "${EXISTING_TAGS}" | grep "${tag}"; then
-            aws ecr put-image --repository-name "${ORB_STR_REPO}" --image-tag "${tag}" --image-manifest "${MANIFEST}"
+            aws ecr put-image --repository-name "${ORB_EVAL_REPO}" --image-tag "${tag}" --image-manifest "${MANIFEST}"
         else
             echo "Tag \"${tag}\" already exists and will be skipped."
         fi
     # tag image when skip_when_tags_exist is false
     else
-        aws ecr put-image --repository-name "${ORB_STR_REPO}" --image-tag "${tag}" --image-manifest "${MANIFEST}"
+        aws ecr put-image --repository-name "${ORB_EVAL_REPO}" --image-tag "${tag}" --image-manifest "${MANIFEST}"
     fi
 done
 set +x


### PR DESCRIPTION
Version `9.0.0` of this orb replaced `eval` with `cicleci env subst`. 

This had unintended consequences like: 

- expanding variables containing sub-shells
- string operations (ie `${CIRCLE_SHA1:0:7}`)

This PR reverts back to using `eval` for variable expansion. 

**PLEASE NOTE: We will be reintroducing `circleci env subst` again in a later major release** but just wanted to make this change to include bug fixes for folks using older versions of the orb. 