### PR TITLE
fix: switch buildx command to fix validation

### DIFF
--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -76,7 +76,7 @@ if [ "${AWS_ECR_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "0" ] || [[ "${AWS_ECR_BOOL_SKIP
     fi
     context_args="--context builder"
   # if no builder instance is currently used, create one
-  elif ! docker buildx inspect | grep -q "default * docker"; then
+  elif ! docker buildx ls | grep -q "default * docker"; then
     docker buildx create --name DLC_builder --use
   fi
 

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -77,7 +77,10 @@ if [ "${AWS_ECR_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "0" ] || [[ "${AWS_ECR_BOOL_SKIP
     context_args="--context builder"
   # if no builder instance is currently used, create one
   elif ! docker buildx ls | grep -q "default * docker"; then
+    set -x
     docker buildx create --name DLC_builder --use
+    echo "Context is set to DLC_builder"
+    set +x
   fi
 
 set -x


### PR DESCRIPTION
This pull request fixes an issue with checking for the current context being used with `docker buildx`.

It switches the `docker buildx inspect` command to `docker buildx ls`, which will correctly check to see if the default context is being used. 

