### PR TITLE
docs: update desciptions to include multi line arguments

### DIFF
--- a/src/commands/build_and_push_image.yml
+++ b/src/commands/build_and_push_image.yml
@@ -119,8 +119,9 @@ parameters:
   extra_build_args:
     default: ""
     description: >
-      Extra flags to pass to docker build. For examples, see
-      https://docs.docker.com/engine/reference/commandline/build
+      Extra flags to pass to docker build. This parameter accepts multi-line arguments. 
+      If your argument spans multiple lines, please use the Folded Block Style denoted by `>-` (e.g. extra_build_args: >-).
+      For examples of available flags, see https://docs.docker.com/engine/reference/commandline/buildx_build
     type: string
 
   no_output_timeout:

--- a/src/commands/build_and_push_image.yml
+++ b/src/commands/build_and_push_image.yml
@@ -119,7 +119,7 @@ parameters:
   extra_build_args:
     default: ""
     description: >
-      Extra flags to pass to docker build. This parameter accepts multi-line arguments. 
+      Extra flags to pass to docker build. This parameter accepts multi-line arguments.
       If your argument spans multiple lines, please use the Folded Block Style denoted by `>-` (e.g. extra_build_args: >-).
       For examples of available flags, see https://docs.docker.com/engine/reference/commandline/buildx_build
     type: string

--- a/src/commands/build_image.yml
+++ b/src/commands/build_image.yml
@@ -42,11 +42,12 @@ parameters:
     description: The amount of time to allow the docker command to run before timing out.
 
   extra_build_args:
-    type: string
     default: ""
     description: >
-      Extra flags to pass to docker build. For examples, see
-      https://docs.docker.com/engine/reference/commandline/buildx
+      Extra flags to pass to docker build. This parameter accepts multi-line arguments. 
+      If your argument spans multiple lines, please use the Folded Block Style denoted by `>-` (e.g. extra_build_args: >-).
+      For examples of available flags, see https://docs.docker.com/engine/reference/commandline/buildx_build
+    type: string
 
   skip_when_tags_exist:
     type: boolean

--- a/src/commands/build_image.yml
+++ b/src/commands/build_image.yml
@@ -44,7 +44,7 @@ parameters:
   extra_build_args:
     default: ""
     description: >
-      Extra flags to pass to docker build. This parameter accepts multi-line arguments. 
+      Extra flags to pass to docker build. This parameter accepts multi-line arguments.
       If your argument spans multiple lines, please use the Folded Block Style denoted by `>-` (e.g. extra_build_args: >-).
       For examples of available flags, see https://docs.docker.com/engine/reference/commandline/buildx_build
     type: string

--- a/src/jobs/build_and_push_image.yml
+++ b/src/jobs/build_and_push_image.yml
@@ -128,11 +128,12 @@ parameters:
     type: string
 
   extra_build_args:
-    type: string
     default: ""
     description: >
-      Extra flags to pass to docker build. For examples, see
-      https://docs.docker.com/engine/reference/commandline/build
+      Extra flags to pass to docker build. This parameter accepts multi-line arguments. 
+      If your argument spans multiple lines, please use the Folded Block Style denoted by `>-` (e.g. extra_build_args: >-).
+      For examples of available flags, see https://docs.docker.com/engine/reference/commandline/buildx_build
+    type: string
 
   no_output_timeout:
     type: string

--- a/src/jobs/build_and_push_image.yml
+++ b/src/jobs/build_and_push_image.yml
@@ -130,7 +130,7 @@ parameters:
   extra_build_args:
     default: ""
     description: >
-      Extra flags to pass to docker build. This parameter accepts multi-line arguments. 
+      Extra flags to pass to docker build. This parameter accepts multi-line arguments.
       If your argument spans multiple lines, please use the Folded Block Style denoted by `>-` (e.g. extra_build_args: >-).
       For examples of available flags, see https://docs.docker.com/engine/reference/commandline/buildx_build
     type: string


### PR DESCRIPTION
This PR updates the description for the `extra_build_args` parameter. For users that want to use multi line arguments, they need to use `>-` instead of `|` like below: 

```
extra_build_args: >-
            --build-arg ARG1=<< parameters.arg1 >>
            --build-arg ARG2=<< parameters.arg2 >>
            --build-arg ARG3=<< parameters.arg3 >>
```