### PR TITLE
fix: fix jq command when working with an existing Docker config.json file

### DIFF
--- a/src/scripts/ecr_login.sh
+++ b/src/scripts/ecr_login.sh
@@ -38,9 +38,10 @@ configure_config_json(){
     if [ ! -s "${CONFIG_FILE}" ]; then
         jq_flag="-n"
     fi
-        jq "${jq_flag}" --arg url "${AWS_ECR_VAL_ACCOUNT_URL}" \
-        --arg helper "ecr-login" '.credHelpers[$url] = $helper' \
-        "${CONFIG_FILE}" > temp.json && mv temp.json "${CONFIG_FILE}"
+
+    jq ${jq_flag} --arg url "${AWS_ECR_VAL_ACCOUNT_URL}" \
+      --arg helper "ecr-login" '.credHelpers[$url] = $helper' \
+      "${CONFIG_FILE}" > temp.json && mv temp.json "${CONFIG_FILE}"
 }
 
 install_aws_ecr_credential_helper(){


### PR DESCRIPTION

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions (not needed)
- [x] Examples have been added for any significant new features (not needed)
- [x] README has been updated, if necessary (not needed)

### Motivation, issues

Fixes #333 

The change is needed to update the `${HOME}/.docker/config.json` file to with multiple ECR entries. The `jq` command currently fails when attempting to add a second ECR entry.
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

Removes double quotes around the `$jq_flag` so that it is properly handled when it is empty. With the double quotes, the `jq` command is interpreting the empty string as a parameter and then failing to find the config file because of how it is parsing the flags. 

I also fix the indentation of the `jq` command so that the staring matches the level of the `if` statement above it and indent the additional parts of the `jq` command a couple extra spaces.

