### PR TITLE
fix(ecr): avoid reaching out to pkg manager if cred helper is installed

### DIFF
--- a/src/scripts/ecr_login.sh
+++ b/src/scripts/ecr_login.sh
@@ -47,11 +47,17 @@ configure_config_json(){
 install_aws_ecr_credential_helper(){
     echo "Installing AWS ECR Credential Helper..."
     if [[ "$SYS_ENV_PLATFORM" = "linux" ]]; then
-        $SUDO apt update
-        $SUDO apt install amazon-ecr-credential-helper
+        HELPER_INSTALLED=$(dpkg --get-selections | grep amazon-ecr-credential-helper | awk '{ print $2 }')
+        if [[ "$HELPER_INSTALLED" != "install" ]]; then
+            $SUDO apt update
+            $SUDO apt install amazon-ecr-credential-helper
+        fi
         configure_config_json
     elif [[ "$SYS_ENV_PLATFORM" = "macos" ]]; then
-        brew install docker-credential-helper-ecr
+        HELPER_INSTALLED=$(brew list -q | grep -q docker-credential-helper-ecr)
+        if [[ "$HELPER_INSTALLED" -ne 0 ]]; then
+            brew install docker-credential-helper-ecr
+        fi
         configure_config_json
     else
         docker logout "${AWS_ECR_VAL_ACCOUNT_URL}"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

After upgrading to 9.1.0, I noticed that logging into ECR was taking 30+ seconds when it used to be instant. After doing some digging, I saw that it was trying to install the credential helper in every CI job, requiring an `apt update`. 

### Description

To remediate the above issue, this does a quick check to see if the credential helper is installed, and does not attempt to install if it's already there. This has the added bonus of reducing external dependencies for this job if it's on a container that already has ecr-credential-helper installed.