### PR TITLE
Only install ecr-credential-helper when not already installed

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -357,7 +357,7 @@ workflows:
                   aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
           matrix:
             parameters:
-              executor: ["amd64", "arm64"]
+              executor: ["amd64", "arm64", "macintosh"]
           filters: *filters
           requires:
             - integration-test-skip_when_tags_exist-populate-image-amd64
@@ -387,3 +387,6 @@ executors:
       image: ubuntu-2204:current
       docker_layer_caching: true
     resource_class: arm.medium
+  macintosh:
+     macos:
+      xcode: "15.4.0"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -357,7 +357,7 @@ workflows:
                   aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
           matrix:
             parameters:
-              executor: ["amd64", "arm64", "macintosh"]
+              executor: ["amd64", "arm64"]
           filters: *filters
           requires:
             - integration-test-skip_when_tags_exist-populate-image-amd64
@@ -387,6 +387,3 @@ executors:
       image: ubuntu-2204:current
       docker_layer_caching: true
     resource_class: arm.medium
-  macintosh:
-     macos:
-      xcode: "15.4.0"

--- a/src/scripts/ecr_login.sh
+++ b/src/scripts/ecr_login.sh
@@ -47,14 +47,14 @@ configure_config_json(){
 install_aws_ecr_credential_helper(){
     echo "Installing AWS ECR Credential Helper..."
     if [[ "$SYS_ENV_PLATFORM" = "linux" ]]; then
-        HELPER_INSTALLED=$(dpkg --get-selections | (grep unzip || test $?) | awk '{print $2}')
+        HELPER_INSTALLED=$(dpkg --get-selections | (grep amazon-ecr-credential-helper || test $?) | awk '{print $2}')
         if [[ "$HELPER_INSTALLED" != "install" ]]; then
             $SUDO apt update
             $SUDO apt install amazon-ecr-credential-helper
         fi
         configure_config_json
     elif [[ "$SYS_ENV_PLATFORM" = "macos" ]]; then
-        HELPER_INSTALLED=$(brew list -q | grep -q docker-credential-helper-ecr)
+        HELPER_INSTALLED=$(brew list -q | grep -q docker-credential-helper-ecr || test $?)
         if [[ "$HELPER_INSTALLED" -ne 0 ]]; then
             brew install docker-credential-helper-ecr
         fi

--- a/src/scripts/ecr_login.sh
+++ b/src/scripts/ecr_login.sh
@@ -47,7 +47,7 @@ configure_config_json(){
 install_aws_ecr_credential_helper(){
     echo "Installing AWS ECR Credential Helper..."
     if [[ "$SYS_ENV_PLATFORM" = "linux" ]]; then
-        HELPER_INSTALLED=$(dpkg --get-selections | grep amazon-ecr-credential-helper | awk '{ print $2 }')
+        HELPER_INSTALLED=$(dpkg --get-selections | (grep unzip || test $?) | awk '{print $2}')
         if [[ "$HELPER_INSTALLED" != "install" ]]; then
             $SUDO apt update
             $SUDO apt install amazon-ecr-credential-helper

--- a/src/scripts/ecr_login.sh
+++ b/src/scripts/ecr_login.sh
@@ -47,11 +47,17 @@ configure_config_json(){
 install_aws_ecr_credential_helper(){
     echo "Installing AWS ECR Credential Helper..."
     if [[ "$SYS_ENV_PLATFORM" = "linux" ]]; then
-        $SUDO apt update
-        $SUDO apt install amazon-ecr-credential-helper
+        HELPER_INSTALLED=$(dpkg --get-selections | grep amazon-ecr-credential-helper | awk '{ print $2 }')
+        if [[ "$HELPER_INSTALLED" != "install" ]]; then
+            $SUDO apt update
+            $SUDO apt install amazon-ecr-credential-helper
+        fi
         configure_config_json
     elif [[ "$SYS_ENV_PLATFORM" = "macos" ]]; then
-        brew install docker-credential-helper-ecr
+        HELPER_INSTALLED=$(brew list -q | grep -q docker-credential-helper-ecr)
+        if [[ "$HELPER_INSTALLED" -ne 0 ]]; then
+            brew install docker-credential-helper-ecr
+        fi
         configure_config_json
     else
         docker logout "${AWS_ECR_VAL_ACCOUNT_URL}"


### PR DESCRIPTION
### Motivation, issues

Users have pointed out that, for various reasons, it is unnecessary to install the `amazon-ecr-credential-helper` every time and that we should instead check first if it is already installed.

This PR picks up from the work done in #348. Thank you @ryandgood  

### Description
- Check if `amazon-ecr-credential-helper` is already installed before attempting to download and install.
