### PR TITLE
Updates to use new version of aws cli

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -130,6 +130,9 @@ workflows:
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "default" 
+                role_session_name: ecr-orb-test-session-buildx
+                region: "us-west-2"
           attach_workspace: true
           workspace_root: workspace
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-build-test-then-push-with-buildx
@@ -152,6 +155,9 @@ workflows:
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "default" 
+                role_session_name: ecr-orb-test-session-nopush
+                region: "us-west-2"
           attach_workspace: true
           workspace_root: workspace
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-multi-platform-without-push
@@ -174,6 +180,9 @@ workflows:
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "default" 
+                role_session_name: ecr-orb-test-session-default
+                region: "us-west-2"
           attach_workspace: true
           workspace_root: workspace
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-default-profile
@@ -197,6 +206,9 @@ workflows:
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "default" 
+                role_session_name: ecr-orb-test-session-cred-helper
+                region: "us-west-2"
           attach_workspace: true
           workspace_root: workspace
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-credential-helper
@@ -227,6 +239,9 @@ workflows:
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "default" 
+                role_session_name: ecr-orb-test-session-cache
+                region: "us-west-2"
           attach_workspace: true
           workspace_root: workspace
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-cache-to-flag
@@ -244,6 +259,8 @@ workflows:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
                 profile_name: "OIDC-User"
+                role_session_name: ecr-orb-test-session-public-registry
+                region: "us-west-2"
           attach_workspace: true
           workspace_root: workspace
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public_registry
@@ -274,6 +291,8 @@ workflows:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
                 profile_name: "OIDC-User"
+                role_session_name: ecr-orb-test-session-cred-helper-<<matrix.use_credentials_helper>>
+                region: "us-west-2"
           attach_workspace: true
           region: "us-west-2"
           profile_name: "OIDC-User"
@@ -302,6 +321,8 @@ workflows:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
                 profile_name: "OIDC-User"
+                role_session_name: ecr-orb-test-session-tag-existing
+                region: "us-west-2"
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile-true
           region: "us-west-2"
           profile_name: "OIDC-User"
@@ -315,7 +336,9 @@ workflows:
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
+                profile_name: "OIDC-User" 
+                role_session_name: ecr-orb-test-session-existing
+                region: "us-west-2"
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile-true
           region: "us-west-2"
           profile_name: "OIDC-User"
@@ -336,6 +359,8 @@ workflows:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
                 profile_name: "OIDC-User"
+                role_session_name: ecr-orb-test-session-populate-<<matrix.executor>>
+                region: "us-west-2"
           attach_workspace: true
           region: "us-west-2"
           profile_name: "OIDC-User"
@@ -361,6 +386,8 @@ workflows:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
                 profile_name: "OIDC-User"
+                role_session_name: ecr-orb-test-session-<<matrix.executor>>
+                region: "us-west-2"
           attach_workspace: true
           region: "us-west-2"
           profile_name: "OIDC-User"
@@ -390,6 +417,8 @@ workflows:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
                 profile_name: "OIDC-User"
+                role_session_name: ecr-orb-test-session-login-<<matrix.executor>>
+                region: "us-west-2"
           profile_name: "OIDC-User"
           region: "us-west-2"
           context: [CPE-OIDC]
@@ -398,6 +427,11 @@ workflows:
             alias: login
             parameters:
               executor: ["arm64", "amd64"]
+          post-steps:
+            - run:
+                name: "Validation"
+                command: |
+                  aws sts get-caller-identity --profile OIDC-User
       - orb-tools/publish:
           orb_name: circleci/aws-ecr
           vcs_type: << pipeline.project.type >>

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -63,6 +63,8 @@ jobs:
         type: executor
       auth:
         type: steps
+      account_id:
+        type: string
     steps:
       - steps: <<parameters.auth>>
       - aws-ecr/ecr_login:
@@ -392,6 +394,8 @@ workflows:
                 profile_name: "OIDC-User"
           profile_name: "OIDC-User"
           region: "us-west-2"
+          context: [CPE-OIDC]
+          requires: [pre-integration]
           matrix:
             alias: login
             parameters:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -258,7 +258,7 @@ workflows:
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
+                profile_name: "default"
                 role_session_name: ecr-orb-test-session-public-registry
                 region: "us-west-2"
           attach_workspace: true
@@ -266,7 +266,7 @@ workflows:
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-public_registry
           create_repo: true
           region: "us-west-2"
-          profile_name: "OIDC-User"
+          profile_name: "default"
           context: [CPE-OIDC]
           tag: integration,myECRRepoTag
           dockerfile: Dockerfile
@@ -277,7 +277,7 @@ workflows:
           post-steps:
             - run:
                 name: "Delete repository"
-                command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public_registry --force --profile OIDC-User
+                command: aws ecr-public delete-repository --region us-east-1 --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-public_registry --force --profile default
           platform: linux/arm64,linux/amd64
           filters: *filters
           requires: [pre-integration]
@@ -290,12 +290,12 @@ workflows:
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
+                profile_name: "default"
                 role_session_name: ecr-orb-test-session-cred-helper-<<matrix.use_credentials_helper>>
                 region: "us-west-2"
           attach_workspace: true
           region: "us-west-2"
-          profile_name: "OIDC-User"
+          profile_name: "default"
           matrix:
             alias: integration-test-named-profile
             parameters:
@@ -320,12 +320,12 @@ workflows:
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
+                profile_name: "default"
                 role_session_name: ecr-orb-test-session-tag-existing
                 region: "us-west-2"
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile-true
           region: "us-west-2"
-          profile_name: "OIDC-User"
+          profile_name: "default"
           context: [CPE-OIDC]
           source_tag: integration
           target_tag: latest
@@ -336,12 +336,12 @@ workflows:
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User" 
+                profile_name: "default" 
                 role_session_name: ecr-orb-test-session-existing
                 region: "us-west-2"
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile-true
           region: "us-west-2"
-          profile_name: "OIDC-User"
+          profile_name: "default"
           context: [CPE-OIDC]
           source_tag: integration
           target_tag: alpha,latest
@@ -349,7 +349,7 @@ workflows:
           post-steps:
             - run:
                 name: "Delete repository"
-                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile-true --force --profile OIDC-User
+                command: aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-named-profile-true --force --profile default
           filters: *filters
           requires:
             - integration-test-tag-existing-image
@@ -358,12 +358,12 @@ workflows:
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
+                profile_name: "default"
                 role_session_name: ecr-orb-test-session-populate-<<matrix.executor>>
                 region: "us-west-2"
           attach_workspace: true
           region: "us-west-2"
-          profile_name: "OIDC-User"
+          profile_name: "default"
           context: [CPE-OIDC]
           workspace_root: workspace
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
@@ -385,12 +385,12 @@ workflows:
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
+                profile_name: "default"
                 role_session_name: ecr-orb-test-session-<<matrix.executor>>
                 region: "us-west-2"
           attach_workspace: true
           region: "us-west-2"
-          profile_name: "OIDC-User"
+          profile_name: "default"
           context: [CPE-OIDC]
           workspace_root: workspace
           repo: aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>>
@@ -403,7 +403,7 @@ workflows:
             - run:
                 name: "Delete repository"
                 command: |
-                  aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
+                  aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>> --force --profile default
           matrix:
             alias: integration-test-skip_when_tags_exist
             parameters:
@@ -416,10 +416,10 @@ workflows:
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-                profile_name: "OIDC-User"
+                profile_name: "default"
                 role_session_name: ecr-orb-test-session-login-<<matrix.executor>>
                 region: "us-west-2"
-          profile_name: "OIDC-User"
+          profile_name: "default"
           region: "us-west-2"
           context: [CPE-OIDC]
           requires: [pre-integration]
@@ -431,7 +431,7 @@ workflows:
             - run:
                 name: "Validation"
                 command: |
-                  aws sts get-caller-identity --profile OIDC-User
+                  aws sts get-caller-identity --profile default
       - orb-tools/publish:
           orb_name: circleci/aws-ecr
           vcs_type: << pipeline.project.type >>

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -354,7 +354,7 @@ workflows:
           matrix:
             alias: integration-test-skip_when_tags_exist-populate-image
             parameters:
-              executor: ["arm64", "amd64", "macos", "alpine", "docker-base"]
+              executor: ["arm64", "amd64"]
           filters: *filters
           requires: [pre-integration]
       - aws-ecr/build_and_push_image:
@@ -382,7 +382,7 @@ workflows:
           matrix:
             alias: integration-test-skip_when_tags_exist
             parameters:
-              executor: ["arm64", "amd64", "macos", "alpine", "docker-base"]
+              executor: ["arm64", "amd64"]
           filters: *filters
           requires:
             - integration-test-skip_when_tags_exist-populate-image
@@ -399,7 +399,7 @@ workflows:
           matrix:
             alias: login
             parameters:
-              executor: ["arm64", "amd64", "macos", "alpine", "docker-base"]
+              executor: ["arm64", "amd64"]
       - orb-tools/publish:
           orb_name: circleci/aws-ecr
           vcs_type: << pipeline.project.type >>
@@ -429,12 +429,3 @@ executors:
       image: ubuntu-2204:current
       docker_layer_caching: true
     resource_class: arm.medium
-  macos:
-    macos:
-      xcode: 15.1.0
-  alpine:
-    docker:
-      - image: alpine:latest
-  docker-base:
-    docker:
-      - image: cimg/base:stable      

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -331,7 +331,7 @@ workflows:
           requires:
             - integration-test-tag-existing-image
       - aws-ecr/build_and_push_image:
-          name: integration-test-skip_when_tags_exist-populate-image
+          name: integration-test-skip_when_tags_exist-populate-image-<<matrix.executor>>
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
@@ -356,7 +356,7 @@ workflows:
           filters: *filters
           requires: [pre-integration]
       - aws-ecr/build_and_push_image:
-          name: integration-test-skip_when_tags_exist
+          name: integration-test-skip_when_tags_exist-<<matrix.executor>>
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
@@ -385,7 +385,7 @@ workflows:
           requires:
             - integration-test-skip_when_tags_exist-populate-image
       - login:
-          name: login
+          name: login-<<matrix.executor>>
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -63,8 +63,6 @@ jobs:
         type: executor
       auth:
         type: steps
-      account_id:
-        type: string
     steps:
       - steps: <<parameters.auth>>
       - aws-ecr/ecr_login:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -278,6 +278,7 @@ workflows:
           region: "us-west-2"
           profile_name: "OIDC-User"
           matrix:
+            alias: integration-test-named-profile
             parameters:
               use_credentials_helper: [true, false]
           context: [CPE-OIDC]
@@ -330,7 +331,7 @@ workflows:
           requires:
             - integration-test-tag-existing-image
       - aws-ecr/build_and_push_image:
-          name: integration-test-skip_when_tags_exist-populate-image-<<matrix.executor>>
+          name: integration-test-skip_when_tags_exist-populate-image
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
@@ -349,12 +350,13 @@ workflows:
           extra_build_args: --compress
           skip_when_tags_exist: true
           matrix:
+            alias: integration-test-skip_when_tags_exist-populate-image
             parameters:
               executor: ["arm64", "amd64", "macos", "alpine", "docker-base"]
           filters: *filters
           requires: [pre-integration]
       - aws-ecr/build_and_push_image:
-          name: integration-test-skip_when_tags_exist-<<matrix.executor>>
+          name: integration-test-skip_when_tags_exist
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
@@ -376,13 +378,14 @@ workflows:
                 command: |
                   aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
           matrix:
+            alias: integration-test-skip_when_tags_exist
             parameters:
               executor: ["arm64", "amd64", "macos", "alpine", "docker-base"]
           filters: *filters
           requires:
             - integration-test-skip_when_tags_exist-populate-image
       - login:
-          name: login-<<matrix.executor>>
+          name: login
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
@@ -390,6 +393,7 @@ workflows:
           profile_name: "OIDC-User"
           region: "us-west-2"
           matrix:
+            alias: login
             parameters:
               executor: ["arm64", "amd64", "macos", "alpine", "docker-base"]
       - orb-tools/publish:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   orb-tools: circleci/orb-tools@12.0
-  aws-cli: circleci/aws-cli@4.0
+  aws-cli: circleci/aws-cli@5.1.0
   aws-ecr: {}
 filters: &filters
   tags:
@@ -52,6 +52,23 @@ jobs:
           source_tag: <<parameters.source_tag>>
           target_tag: <<parameters.target_tag>>
           profile_name: <<parameters.profile_name>>
+  login:
+    executor: <<parameters.executor>>
+    parameters:
+      region:
+        type: string
+      profile_name:
+        type: string
+      executor:
+        type: executor
+      auth:
+        type: steps
+    steps:
+      - steps: <<parameters.auth>>
+      - aws-ecr/ecr_login:
+          profile_name: <<parameters.profile_name>>
+          region: <<parameters.region>>
+      
   build-test-then-push-with-buildx:
     machine:
       image: ubuntu-2204:current
@@ -313,7 +330,7 @@ workflows:
           requires:
             - integration-test-tag-existing-image
       - aws-ecr/build_and_push_image:
-          name: integration-test-skip_when_tags_exist-populate-image-<<matrix.executor>>
+          name: integration-test-skip_when_tags_exist-populate-image
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
@@ -333,11 +350,11 @@ workflows:
           skip_when_tags_exist: true
           matrix:
             parameters:
-              executor: ["arm64", "amd64"]
+              executor: ["arm64", "amd64", "macos", "alpine", "docker-base"]
           filters: *filters
           requires: [pre-integration]
       - aws-ecr/build_and_push_image:
-          name: integration-test-skip_when_tags_exist-<<matrix.executor>>
+          name: integration-test-skip_when_tags_exist
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
@@ -360,23 +377,36 @@ workflows:
                   aws ecr delete-repository --repository-name aws-ecr-orb-${CIRCLE_SHA1:0:7}-skip_when_tags_exist-<<matrix.executor>> --force --profile OIDC-User
           matrix:
             parameters:
-              executor: ["amd64", "arm64"]
+              executor: ["arm64", "amd64", "macos", "alpine", "docker-base"]
           filters: *filters
           requires:
-            - integration-test-skip_when_tags_exist-populate-image-amd64
-            - integration-test-skip_when_tags_exist-populate-image-arm64
-      - orb-tools/lint:
-          filters: *filters
-      - orb-tools/pack:
-          filters: *filters
-      - orb-tools/review:
-          filters: *release-filters
+            - integration-test-skip_when_tags_exist-populate-image
+      - login:
+          auth:
+            - aws-cli/setup:
+                role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+                profile_name: "OIDC-User"
+          profile_name: "OIDC-User"
+          region: "us-west-2"
+          matrix:
+            parameters:
+              executor: ["arm64", "amd64", "macos", "alpine", "docker-base"]
       - orb-tools/publish:
           orb_name: circleci/aws-ecr
           vcs_type: << pipeline.project.type >>
           pub_type: production
           enable_pr_comment: true
-          requires: [ orb-tools/lint, orb-tools/review, orb-tools/pack, integration-test-default-profile, integration-test-pubic-registry, integration-test-skip_when_tags_exist-amd64, integration-test-skip_when_tags_exist-arm64, integration-test-named-profile-true-helper, integration-test-named-profile-false-helper, integration-test-tag-existing-image, integration-test-tag-image-with-existing-tag ]
+          requires:
+          - build-test-then-push-with-buildx
+          - integration-test-multi-platform-without-push
+          - integration-test-default-profile
+          - integration-test-aws-ecr-credential-helper
+          - integration-test-cache-to-flag
+          - integration-test-pubic-registry
+          - integration-test-skip_when_tags_exist
+          - integration-test-named-profile-false-helper
+          - login
+          - integration-test-tag-image-with-existing-tag
           github_token: GHI_TOKEN
           context: orb-publisher
           filters: *release-filters
@@ -390,3 +420,12 @@ executors:
       image: ubuntu-2204:current
       docker_layer_caching: true
     resource_class: arm.medium
+  macos:
+    macos:
+      xcode: 15.1.0
+  alpine:
+    docker:
+      - image: alpine:latest
+  docker-base:
+    docker:
+      - image: cimg/base:stable      

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -330,7 +330,7 @@ workflows:
           requires:
             - integration-test-tag-existing-image
       - aws-ecr/build_and_push_image:
-          name: integration-test-skip_when_tags_exist-populate-image
+          name: integration-test-skip_when_tags_exist-populate-image-<<matrix.executor>>
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
@@ -354,7 +354,7 @@ workflows:
           filters: *filters
           requires: [pre-integration]
       - aws-ecr/build_and_push_image:
-          name: integration-test-skip_when_tags_exist
+          name: integration-test-skip_when_tags_exist-<<matrix.executor>>
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
@@ -382,6 +382,7 @@ workflows:
           requires:
             - integration-test-skip_when_tags_exist-populate-image
       - login:
+          name: login-<<matrix.executor>>
           auth:
             - aws-cli/setup:
                 role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST

--- a/src/scripts/ecr_login.sh
+++ b/src/scripts/ecr_login.sh
@@ -51,7 +51,7 @@ install_aws_ecr_credential_helper(){
         HELPER_INSTALLED=$(dpkg --get-selections | (grep amazon-ecr-credential-helper || test $?) | awk '{print $2}')
         if [[ "$HELPER_INSTALLED" != "install" ]]; then
             $SUDO apt update
-            $SUDO apt install amazon-ecr-credential-helper
+            $SUDO apt -y install amazon-ecr-credential-helper
         fi
         configure_config_json
     elif [[ "$SYS_ENV_PLATFORM" = "macos" && "$AWS_ECR_BOOL_HELPER" = "1" ]]; then


### PR DESCRIPTION
The tests were using an old version of the aws-cli that has a differente behavior when using OIDC authentication, I'm updating it to the newest.
Also refactoring the strucutre of the tests.

As mentioned in #352, the installation of credentials helper might ask for confirmation in environments with missing packages making the workflow fail, I'm adding the -y flag to the install command to avoid this.