### PR TITLE
Update path description on job

### DIFF
--- a/src/jobs/build_and_push_image.yml
+++ b/src/jobs/build_and_push_image.yml
@@ -119,7 +119,7 @@ parameters:
   path:
     type: string
     default: .
-    description: Path to the directory containing your Dockerfile and build context. Defaults to . (working directory).
+    description: Path to the directory containing your Dockerfile. Defaults to . (working directory).
 
   build_path:
     default: .


### PR DESCRIPTION
#342  describes an issue with the description of the PATH parameter in build_and_push_image job. This parameter is used to pass Dockerfile location only, and is not intended to overwrite or be overwritten. The BUILD_PATH parameter is used to pass the context location only, and is not intended for overwriting either.
I'm updating the description to make this more clear, as the command with the same name.