### PR TITLE
Add validation before creating DLC_builder

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -107,6 +107,17 @@ jobs:
           path: << parameters.path >>
           platform: << parameters.platform >>
           push_image: << parameters.push_image >>
+      - aws-ecr/build_and_push_image:
+          auth: << parameters.auth >>
+          attach_workspace: << parameters.attach_workspace >>
+          workspace_root: << parameters.workspace_root >>
+          repo: << parameters.repo >>
+          create_repo: false
+          tag: dummy
+          dockerfile: << parameters.dockerfile >>
+          path: << parameters.path >>
+          platform: << parameters.platform >>
+          push_image: false
       - run:
           name: Tests for docker image
           command: |

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -82,7 +82,11 @@ if [ "${AWS_ECR_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "0" ] || [[ "${AWS_ECR_BOOL_SKIP
   # if no builder instance is currently used, create one
   elif ! docker buildx ls | grep -q "default * docker"; then
     set -x
-    docker buildx create --name DLC_builder --use
+    if ! docker buildx ls | grep -q DLC_builder; then
+      docker buildx create --name DLC_builder --use
+    else
+      docker buildx use DLC_builder
+    fi
     echo "Context is set to DLC_builder"
     set +x
   fi


### PR DESCRIPTION
Resolves #358 

When the builder is already created and the create is executed, it fails. I'm adding a validation so it creates only when doesn't exist, otherwise use it. I'm also adding a test to test this behavior.
