### PR TITLE
Fix example content missing on CircleCI

### DIFF
--- a/src/examples/build_and_push_image_w_registry_login.yml
+++ b/src/examples/build_and_push_image_w_registry_login.yml
@@ -13,24 +13,24 @@ usage:
     aws-ecr: circleci/aws-ecr@9.0
     # importing aws-cli orb is required for authentication
     aws-cli: circleci/aws-cli@4.0
-workflows:
-  build-and-push-image-with-container-registry-login:
-    jobs:
-      - aws-ecr/build_and_push_image:
-          # must set container registry login to true
-          container_registry_login: true
-          container_registry_login_step:
-            # custom login step for heroku.
-            - run: docker login -u ${HEROKU_USERNAME} -p ${HEROKU_API_KEY}
-            # custom login step for GitHub Container Registry.
-            - run: docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN}
-            # custom login step for DockerHub.
-            - run: docker login -u ${DOCKERHUB_ID} -p ${DOCKERHUB_PASSWORD}
-          auth:
-            - aws-cli/setup:
-                role_arn: arn:aws:iam::123456789012
-          repo: my-sample-repo
-          tag: sampleTag
-          dockerfile: Dockerfile
-          path: .
-          region: us-west-2
+  workflows:
+    build-and-push-image-with-container-registry-login:
+      jobs:
+        - aws-ecr/build_and_push_image:
+            # must set container registry login to true
+            container_registry_login: true
+            container_registry_login_step:
+              # custom login step for heroku.
+              - run: docker login -u ${HEROKU_USERNAME} -p ${HEROKU_API_KEY}
+              # custom login step for GitHub Container Registry.
+              - run: docker login -u ${GITHUB_USERNAME} -p ${GITHUB_TOKEN}
+              # custom login step for DockerHub.
+              - run: docker login -u ${DOCKERHUB_ID} -p ${DOCKERHUB_PASSWORD}
+            auth:
+              - aws-cli/setup:
+                  role_arn: arn:aws:iam::123456789012
+            repo: my-sample-repo
+            tag: sampleTag
+            dockerfile: Dockerfile
+            path: .
+            region: us-west-2

--- a/src/examples/build_test_then_push_image.yml
+++ b/src/examples/build_test_then_push_image.yml
@@ -48,8 +48,8 @@ usage:
             repo: << parameters.repo >>
             region: << parameters.region >>
             tag: << parameters.tag >>
-workflows:
-  build-image-test-image-push-image-with-buildx:
-    jobs:
-      - build-test-then-push-with-buildx:
-          context: CircleCI_OIDC_Token
+  workflows:
+    build-image-test-image-push-image-with-buildx:
+      jobs:
+        - build-test-then-push-with-buildx:
+            context: CircleCI_OIDC_Token


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
The example in the CircleCI registry doesn't show the contents of the workflow: https://circleci.com/developer/orbs/orb/circleci/aws-ecr#usage-build_and_push_image_w_registry_login
![Screenshot 2024-09-30 at 20 50 12](https://github.com/user-attachments/assets/1455aa5a-7e57-4490-8adc-4fd03307ca0d)


### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
Indent example YAML properly
