### PR TITLE
Fix issue with spaces on extra_build_args

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -321,6 +321,7 @@ workflows:
           extra_build_args: >-
             --build-arg NPM_TOKEN=${NPM_TOKEN}
             --build-arg=${CIRCLE_SHA1:0:7}
+            --build-arg=TEST='This is a test'
           set_repo_policy: true
           repo_policy_path: ./sample/repo-policy.json
           executor: amd64

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -321,7 +321,7 @@ workflows:
           extra_build_args: >-
             --build-arg NPM_TOKEN=${NPM_TOKEN}
             --build-arg ${CIRCLE_SHA1:0:7}
-            '--build-arg=TEST='This is a test'
+            --build-arg=TEST='This is a test'
           set_repo_policy: true
           repo_policy_path: ./sample/repo-policy.json
           executor: amd64

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -320,8 +320,8 @@ workflows:
           path: workspace
           extra_build_args: >-
             --build-arg NPM_TOKEN=${NPM_TOKEN}
-            --build-arg=${CIRCLE_SHA1:0:7}
-            '--build-arg TEST=This is a test'
+            --build-arg ${CIRCLE_SHA1:0:7}
+            '--build-arg=TEST='This is a test'
           set_repo_policy: true
           repo_policy_path: ./sample/repo-policy.json
           executor: amd64

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -321,7 +321,7 @@ workflows:
           extra_build_args: >-
             --build-arg NPM_TOKEN=${NPM_TOKEN}
             --build-arg=${CIRCLE_SHA1:0:7}
-            --build-arg=TEST='This is a test'
+            '--build-arg TEST=This is a test'
           set_repo_policy: true
           repo_policy_path: ./sample/repo-policy.json
           executor: amd64

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -15,5 +15,4 @@ parameters:
 machine:
   image: <<parameters.image>>
   docker_layer_caching: <<parameters.docker_layer_caching>>
-shell: bash -eox pipefail
 resource_class: <<parameters.resource_class>>

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -15,5 +15,5 @@ parameters:
 machine:
   image: <<parameters.image>>
   docker_layer_caching: <<parameters.docker_layer_caching>>
-
+shell: bash -eox pipefail
 resource_class: <<parameters.resource_class>>

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 AWS_ECR_EVAL_REGION="$(eval echo "${AWS_ECR_STR_REGION}")"
 AWS_ECR_EVAL_REPO="$(eval echo "${AWS_ECR_STR_REPO}")"
 AWS_ECR_EVAL_TAG="$(eval echo "${AWS_ECR_STR_TAG}")"

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -21,11 +21,9 @@ if [ -n "${AWS_ECR_STR_EXTRA_BUILD_ARGS}" ]; then
   args=()
   # shellcheck disable=SC2086
   eval 'for p in '$AWS_ECR_STR_EXTRA_BUILD_ARGS'; do args+=("$p"); done'
-  echo "$args"
   for arg in "${args[@]}"; do
     set -- "$@" "$arg"
   done
-  echo "$@"
 fi
 set +x
 ECR_COMMAND="ecr"

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -16,7 +16,7 @@ AWS_ECR_EVAL_PLATFORM="$(eval echo "${AWS_ECR_STR_PLATFORM}")"
 AWS_ECR_EVAL_LIFECYCLE_POLICY_PATH="$(eval echo "${AWS_ECR_STR_LIFECYCLE_POLICY_PATH}")"
 # shellcheck disable=SC2034 # used indirectly via environment in `docker buildx` builds
 BUILDX_NO_DEFAULT_ATTESTATIONS=1
-set -x
+
 if [ -n "${AWS_ECR_STR_EXTRA_BUILD_ARGS}" ]; then
   args=()
   # shellcheck disable=SC2086
@@ -25,7 +25,7 @@ if [ -n "${AWS_ECR_STR_EXTRA_BUILD_ARGS}" ]; then
     set -- "$@" "$arg"
   done
 fi
-set +x
+
 ECR_COMMAND="ecr"
 number_of_tags_in_ecr=0
 

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -17,7 +17,7 @@ AWS_ECR_EVAL_LIFECYCLE_POLICY_PATH="$(eval echo "${AWS_ECR_STR_LIFECYCLE_POLICY_
 BUILDX_NO_DEFAULT_ATTESTATIONS=1
 
 if [ -n "${AWS_ECR_STR_EXTRA_BUILD_ARGS}" ]; then
-  IFS=" " read -a args -r <<<"${AWS_ECR_STR_EXTRA_BUILD_ARGS[@]}"
+  eval 'for p in '$EXTRA_BUILD_ARGS'; do args+=("$p"); done'
   for arg in "${args[@]}"; do
     set -- "$@" "$arg"
   done

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -13,11 +13,12 @@ AWS_ECR_EVAL_DOCKERFILE="$(eval echo "${AWS_ECR_STR_DOCKERFILE}")"
 AWS_ECR_EVAL_PROFILE_NAME="$(eval echo "${AWS_ECR_STR_PROFILE_NAME}")"
 AWS_ECR_EVAL_PLATFORM="$(eval echo "${AWS_ECR_STR_PLATFORM}")"
 AWS_ECR_EVAL_LIFECYCLE_POLICY_PATH="$(eval echo "${AWS_ECR_STR_LIFECYCLE_POLICY_PATH}")"
-# shellcheck disable=SC2034,SC2086 # used indirectly via environment in `docker buildx` builds
+# shellcheck disable=SC2034 # used indirectly via environment in `docker buildx` builds
 BUILDX_NO_DEFAULT_ATTESTATIONS=1
 
 if [ -n "${AWS_ECR_STR_EXTRA_BUILD_ARGS}" ]; then
   args=()
+  # shellcheck disable=SC2086
   eval 'for p in '$EXTRA_BUILD_ARGS'; do args+=("$p"); done'
   for arg in "${args[@]}"; do
     set -- "$@" "$arg"

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+
 AWS_ECR_EVAL_REGION="$(eval echo "${AWS_ECR_STR_REGION}")"
 AWS_ECR_EVAL_REPO="$(eval echo "${AWS_ECR_STR_REPO}")"
 AWS_ECR_EVAL_TAG="$(eval echo "${AWS_ECR_STR_TAG}")"
@@ -16,15 +16,18 @@ AWS_ECR_EVAL_PLATFORM="$(eval echo "${AWS_ECR_STR_PLATFORM}")"
 AWS_ECR_EVAL_LIFECYCLE_POLICY_PATH="$(eval echo "${AWS_ECR_STR_LIFECYCLE_POLICY_PATH}")"
 # shellcheck disable=SC2034 # used indirectly via environment in `docker buildx` builds
 BUILDX_NO_DEFAULT_ATTESTATIONS=1
-
+set -x
 if [ -n "${AWS_ECR_STR_EXTRA_BUILD_ARGS}" ]; then
   args=()
   # shellcheck disable=SC2086
-  eval 'for p in '$EXTRA_BUILD_ARGS'; do args+=("$p"); done'
+  eval 'for p in '$AWS_ECR_STR_EXTRA_BUILD_ARGS'; do args+=("$p"); done'
+  echo "$args"
   for arg in "${args[@]}"; do
     set -- "$@" "$arg"
   done
+  echo "$@"
 fi
+set +x
 ECR_COMMAND="ecr"
 number_of_tags_in_ecr=0
 

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -13,10 +13,11 @@ AWS_ECR_EVAL_DOCKERFILE="$(eval echo "${AWS_ECR_STR_DOCKERFILE}")"
 AWS_ECR_EVAL_PROFILE_NAME="$(eval echo "${AWS_ECR_STR_PROFILE_NAME}")"
 AWS_ECR_EVAL_PLATFORM="$(eval echo "${AWS_ECR_STR_PLATFORM}")"
 AWS_ECR_EVAL_LIFECYCLE_POLICY_PATH="$(eval echo "${AWS_ECR_STR_LIFECYCLE_POLICY_PATH}")"
-# shellcheck disable=SC2034 # used indirectly via environment in `docker buildx` builds
+# shellcheck disable=SC2034,SC2086 # used indirectly via environment in `docker buildx` builds
 BUILDX_NO_DEFAULT_ATTESTATIONS=1
 
 if [ -n "${AWS_ECR_STR_EXTRA_BUILD_ARGS}" ]; then
+  args=()
   eval 'for p in '$EXTRA_BUILD_ARGS'; do args+=("$p"); done'
   for arg in "${args[@]}"; do
     set -- "$@" "$arg"


### PR DESCRIPTION
I'm adding a new way to parse the extra args to the build script, so the parameters with spaces don't have errors.
This is similar to the implementation done in docker-orb, and also requires the = when using spaces to avoid problems.