### PR TITLE
Only list images when their use case is not skipped

### DIFF
--- a/src/scripts/tag_image.sh
+++ b/src/scripts/tag_image.sh
@@ -7,7 +7,10 @@ AWS_ECR_EVAL_AWS_PROFILE="$(eval echo "${AWS_ECR_STR_AWS_PROFILE}")"
 # pull the image manifest from ECR
 set -x
 MANIFEST="$(aws ecr batch-get-image --repository-name "${AWS_ECR_EVAL_REPO}" --image-ids imageTag="${AWS_ECR_EVAL_SOURCE_TAG}" --query 'images[].imageManifest' --output text --profile "${AWS_ECR_EVAL_AWS_PROFILE}")"
-EXISTING_TAGS="$(aws ecr list-images --repository-name "${AWS_ECR_EVAL_REPO}" --filter "tagStatus=TAGGED" --profile "${AWS_ECR_EVAL_AWS_PROFILE}")"
+# only list images when needed
+if [ "${AWS_ECR_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq 1 ]; then
+    EXISTING_TAGS="$(aws ecr list-images --repository-name "${AWS_ECR_EVAL_REPO}" --filter "tagStatus=TAGGED" --profile "${AWS_ECR_EVAL_AWS_PROFILE}")"
+fi
 IFS="," read -ra ECR_TAGS <<<"${AWS_ECR_EVAL_TARGET_TAG}"
 
 for tag in "${ECR_TAGS[@]}"; do


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

My CI AWS profile is given an aws managed policy which does not have `ecr:ListImages` permission. [EC2InstanceProfileForImageBuilderECRContainerBuilds](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/EC2InstanceProfileForImageBuilderECRContainerBuilds.html) 

### Description

The `tag_image` command has a flag to `skip_when_tags_exist` (default false). When the flag is not set, there is no use for the `ListImages` output.
