### PR TITLE
Add docker_buildx_name param

### DIFF
--- a/src/commands/build_and_push_image.yml
+++ b/src/commands/build_and_push_image.yml
@@ -207,6 +207,14 @@ parameters:
     description: >
       When true the authentication to docker registry will be done using the ecr-credential-helper. This avoids having
       the password saved in plain text. Otherwise it will use the classic docker login command which is more compatible.
+
+  docker_buildx_name:
+    type: string
+    default: DLC_builder
+    description: >
+      A name for the docker buildx instance. Defaults to DLC_builder.
+      Note: DLC Cache will be generated from this name so it should be unique for each build job in the workflow.
+
 steps:
   - when:
       condition: <<parameters.checkout>>
@@ -279,3 +287,4 @@ steps:
       public_registry_alias: <<parameters.public_registry_alias>>
       build_path: <<parameters.build_path>>
       aws_domain: <<parameters.aws_domain>>
+      docker_buildx_name: <<parameters.docker_buildx_name>>

--- a/src/commands/build_image.yml
+++ b/src/commands/build_image.yml
@@ -106,6 +106,13 @@ parameters:
       The AWS domain for your region, e.g in China, the AWS domain is amazonaws.com.cn
       The default value is amazonaws.com
 
+  docker_buildx_name:
+    type: string
+    default: DLC_builder
+    description: >
+      A name for the docker buildx instance. Defaults to DLC_builder.
+      Note: DLC Cache will be generated from this name so it should be unique for each build job in the workflow.
+
 steps:
   - run:
       name: Build Docker Image with buildx
@@ -126,5 +133,6 @@ steps:
         AWS_ECR_STR_PUBLIC_REGISTRY_ALIAS: <<parameters.public_registry_alias>>
         AWS_ECR_EVAL_BUILD_PATH: <<parameters.build_path>>
         AWS_ECR_STR_AWS_DOMAIN: <<parameters.aws_domain>>
+        AWS_ECR_STR_DOCKER_BUILDX_NAME: <<parameters.docker_buildx_name>>
       command: <<include(scripts/docker_buildx.sh)>>
       no_output_timeout: <<parameters.no_output_timeout>>

--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -14,6 +14,7 @@ AWS_ECR_EVAL_DOCKERFILE="$(eval echo "${AWS_ECR_STR_DOCKERFILE}")"
 AWS_ECR_EVAL_PROFILE_NAME="$(eval echo "${AWS_ECR_STR_PROFILE_NAME}")"
 AWS_ECR_EVAL_PLATFORM="$(eval echo "${AWS_ECR_STR_PLATFORM}")"
 AWS_ECR_EVAL_LIFECYCLE_POLICY_PATH="$(eval echo "${AWS_ECR_STR_LIFECYCLE_POLICY_PATH}")"
+AWS_ECR_EVAL_DOCKER_BUILDX_NAME="$(eval echo "${AWS_ECR_STR_DOCKER_BUILDX_NAME}")"
 # shellcheck disable=SC2034 # used indirectly via environment in `docker buildx` builds
 BUILDX_NO_DEFAULT_ATTESTATIONS=1
 
@@ -80,18 +81,18 @@ if [ "${AWS_ECR_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "0" ] || [[ "${AWS_ECR_BOOL_SKIP
       # otherwise the command will fail when called more than once in the same job.
       docker context create builder
       docker run --privileged --rm tonistiigi/binfmt --install all
-      docker --context builder buildx create --name DLC_builder --use
+      docker --context builder buildx create --name "$AWS_ECR_EVAL_DOCKER_BUILDX_NAME" --use
     fi
     context_args="--context builder"
   # if no builder instance is currently used, create one
   elif ! docker buildx ls | grep -q "default * docker"; then
     set -x
-    if ! docker buildx ls | grep -q DLC_builder; then
-      docker buildx create --name DLC_builder --use
+    if ! docker buildx ls | grep -q "$AWS_ECR_EVAL_DOCKER_BUILDX_NAME"; then
+      docker buildx create --name "$AWS_ECR_EVAL_DOCKER_BUILDX_NAME" --use
     else
-      docker buildx use DLC_builder
+      docker buildx use "$AWS_ECR_EVAL_DOCKER_BUILDX_NAME"
     fi
-    echo "Context is set to DLC_builder"
+    echo "Context is set to $AWS_ECR_EVAL_DOCKER_BUILDX_NAME"
     set +x
   fi
 


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

https://github.com/CircleCI-Public/aws-ecr-orb/issues/364

### Description

This PR adds a new optional field named `docker_buildx_name` which allows the caller the specify an override for the default Docker buildx instance name. This should avoid races and collisions when concurrently uploading the DLC cache across build jobs.