### PR TITLE
Do not fail when docker pull fails

### DIFF
--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -49,7 +49,7 @@ for tag in "${DOCKER_TAGS[@]}"; do
     if [ "${docker_tag_exists_in_ecr}" = "true" ]; then
       IFS="," read -ra PLATFORMS <<<"${AWS_ECR_EVAL_PLATFORM}"
       for p in "${PLATFORMS[@]}"; do
-        docker pull "${AWS_ECR_VAL_ACCOUNT_URL}/${AWS_ECR_EVAL_REPO}:${tag}" --platform "${p}"
+        docker pull "${AWS_ECR_VAL_ACCOUNT_URL}/${AWS_ECR_EVAL_REPO}:${tag}" --platform "${p}" || true
       done
       number_of_tags_in_ecr=$((number_of_tags_in_ecr += 1))
     fi


### PR DESCRIPTION
It might happen that an specific tag already exists but for a different architecture. In that situation it will try to pull it and fail.
I'm updating the behavior so it keeps pulling when the tag exists, but it doesn't fail in case the pull fails.
It doesn't affect the behavior of the script as the pull is only done to avoid rebuilding the image when it exists.
Resolves #384 