### PR TITLE
fix: do not recreate builder if exists

### DIFF
--- a/src/scripts/docker_buildx.sh
+++ b/src/scripts/docker_buildx.sh
@@ -80,7 +80,10 @@ if [ "${AWS_ECR_BOOL_SKIP_WHEN_TAGS_EXIST}" -eq "0" ] || [[ "${AWS_ECR_BOOL_SKIP
       # otherwise the command will fail when called more than once in the same job.
       docker context create builder
       docker run --privileged --rm "tonistiigi/binfmt:$PARAM_BINFMT_VERSION" --install all
-      docker --context builder buildx create --name DLC_builder --use
+      builder_exists="$(docker --context builder buildx ls --format json | jq -s 'any(.[]; .Name == "DLC_builder")')"
+      if [ "${builder_exists}" != "true" ]; then
+        docker --context builder buildx create --name DLC_builder --use
+      fi
     fi
     context_args="--context builder"
   # if no builder instance is currently used, create one


### PR DESCRIPTION
### Checklist

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

Fixes #387

### Description

Do not create a new builder when it already exists with the same name,
which solves a potential issue when running `build_image` multiple times.

