### PR TITLE
Add `account_id` parameter to `tag_image` command

### DIFF
--- a/src/commands/tag_image.yml
+++ b/src/commands/tag_image.yml
@@ -3,6 +3,12 @@ description: >
   NOTE: Some commands may not work with AWS CLI Version 1.
 
 parameters:
+  account_id:
+    type: string
+    default: ""
+    description: >
+      The 12 digit AWS Account ID associated with the ECR account.
+
   repo:
     type: string
     description: Name of an Amazon ECR repository
@@ -42,5 +48,6 @@ steps:
         AWS_ECR_STR_TARGET_TAG: <<parameters.target_tag>>
         AWS_ECR_BOOL_SKIP_WHEN_TAGS_EXIST: <<parameters.skip_when_tags_exist>>
         AWS_ECR_STR_AWS_PROFILE: <<parameters.profile_name>>
+        AWS_ECR_STR_ACCOUNT_ID: <<parameters.account_id>>
         AWS_ECR_STR_EXTRA_ARGS: <<parameters.extra_args>>
       command: <<include(scripts/tag_image.sh)>>

--- a/src/scripts/tag_image.sh
+++ b/src/scripts/tag_image.sh
@@ -2,6 +2,7 @@
 AWS_ECR_EVAL_REPO="$(eval echo "${AWS_ECR_STR_REPO}")"
 AWS_ECR_EVAL_SOURCE_TAG="$(eval echo "${AWS_ECR_STR_SOURCE_TAG}")"
 AWS_ECR_EVAL_TARGET_TAG="$(eval echo "${AWS_ECR_STR_TARGET_TAG}")"
+AWS_ECR_EVAL_ACCOUNT_ID="$(eval echo "${AWS_ECR_STR_ACCOUNT_ID}")"
 AWS_ECR_EVAL_AWS_PROFILE="$(eval echo "${AWS_ECR_STR_AWS_PROFILE}")"
 
 # pull the image manifest from ECR
@@ -17,6 +18,10 @@ extra_args=()
 if [ -n "$AWS_ECR_STR_EXTRA_ARGS" ]; then
 # shellcheck disable=SC2086
   eval 'for p in '$AWS_ECR_STR_EXTRA_ARGS'; do extra_args+=("$p"); done'
+fi
+
+if [ -n "${AWS_ECR_EVAL_ACCOUNT_ID}" ]; then
+    extra_args+=("--registry-id \"${AWS_ECR_EVAL_ACCOUNT_ID}\"")
 fi
 
 for tag in "${ECR_TAGS[@]}"; do


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
- Part of https://github.com/CircleCI-Public/aws-ecr-orb/issues/338

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Adds an optional paramter `account_id` to `tag_image` command. This parameter already exists in multiple commands, including the `build_image`, `push_image`, and `build_and_push_image`.