### PR TITLE
Fix image-tag-mutability-exclusion-filters flag  

### DIFF
--- a/src/scripts/create_repo.sh
+++ b/src/scripts/create_repo.sh
@@ -28,9 +28,9 @@ else
     fi
 
     if [ "${AWS_ECR_EVAL_IMAGE_TAG_MUTABILITY}" == "IMMUTABLE_WITH_EXCLUSION" ] && [ -n "${AWS_ECR_EVAL_IMAGE_TAG_EXCLUSION_FILTERS}" ]; then
+      set -- "$@" --image-tag-mutability-exclusion-filters
       IFS=',' read -ra FILTERS <<< "${AWS_ECR_EVAL_IMAGE_TAG_EXCLUSION_FILTERS}"
       for filter in "${FILTERS[@]}"; do
-        set -- "$@" --image-tag-mutability-exclusion-filters
         set -- "$@" "filterType=WILDCARD,filter=${filter}"
       done
     fi


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Fixes a bug in the IMMUTABLE_WITH_EXCLUSION implementation where only the last exclusion filter was being applied when multiple filters were provided.

### Description

Fix image_tag_exclusion_filters to correctly handle multiple comma-separated filters.

#### Issue:
When passing multiple filters (e.g., "foo,bar"), only the last filter was being applied to the repository due to incorrect AWS CLI argument syntax.

#### Fix:
Updated create_repo.sh to use AWS CLI shorthand syntax for array parameters (space-separated values) instead of repeating the --image-tag-mutability-exclusion-filters flag for each filter.

Before:
```bash
--image-tag-mutability-exclusion-filters filterType=WILDCARD,filter=foo \
--image-tag-mutability-exclusion-filters filterType=WILDCARD,filter=bar
```

After:
```bash
--image-tag-mutability-exclusion-filters \
  filterType=WILDCARD,filter=foo \
  filterType=WILDCARD,filter=bar
```